### PR TITLE
Chrome拡張 ai一括質問 obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
-# mirror-chat
+# AI一括質問＆Obsidian保存ツール
+
+Chrome拡張機能からプロンプトを入力し、4つのAIサービス（ChatGPT, Claude, Gemini, Grok）に順次自動送信して回答を取得し、Obsidian Local REST API経由でMarkdownファイルとして保存するツールです。
+
+## 機能
+
+- **一括質問**: 1つのプロンプトを4つのAIに順次送信（Bot対策のため同時送信ではなく順次送信）
+- **Obsidian連携**: 回答をMarkdownファイルとして自動保存
+- **フォルダ構成**: `AI-Research/YYYY-MM-DD_質問の先頭20文字/` に各AIの回答とSummaryを保存
+- **エラーハンドリング**: Obsidian未起動時はローカルに一時保存し、後から再送信可能
+- **デスクトップ通知**: 完了時・エラー時に通知
+
+## セットアップ
+
+### 1. Obsidian Local REST API の準備
+
+1. Obsidianで「Local REST API」プラグインをインストール・有効化
+2. プラグイン設定でAPIキー（Bearer トークン）とポート番号を確認
+3. デフォルトポート: 27124（HTTP）
+
+### 2. Chrome拡張のインストール
+
+1. このリポジトリをクローン
+2. Chromeで `chrome://extensions/` を開く
+3. 「デベロッパーモード」を有効化
+4. 「パッケージ化されていない拡張機能を読み込む」で `ai-prompt-broadcaster` フォルダを選択
+
+### 3. 設定
+
+1. 拡張アイコンをクリック → 「設定」を開く
+2. Obsidianのポート番号、APIキー、保存先ベースパスを入力
+3. （オプション）AIサービスのUI変更で動作しなくなった場合、DOMセレクタを調整
+
+## 使い方
+
+1. ChatGPT, Claude, Gemini, Grok のいずれかにログイン済みであること
+2. 拡張アイコンをクリック
+3. 質問を入力して「送信して保存」をクリック
+4. 4つのAIタブが順次開き、回答が収集される
+5. 完了時にObsidianに保存され、通知が表示される
+
+## 保存されるファイル
+
+```
+AI-Research/
+└── YYYY-MM-DD_質問の先頭20文字/
+    ├── question.md    # 元の質問
+    ├── ChatGPT.md
+    ├── Claude.md
+    ├── Gemini.md
+    ├── Grok.md
+    └── Summary.md    # 全回答をまとめたファイル
+```
+
+## トラブルシューティング
+
+- **Obsidianに保存できない**: 設定画面でポート・APIキーを確認。Obsidianが起動しているか確認。
+- **AIの入力欄が見つからない**: 設定画面の「セレクタをデフォルトに戻す」を試す。UIが変更されている場合はセレクタを手動調整。
+- **保存に失敗したデータ**: 設定画面の「保存に失敗したデータ」から再送信可能。
+
+## 技術構成
+
+- Manifest V3
+- Content Scripts: 各AIサイト用のDOM操作
+- Background Service Worker: キュー処理、Obsidian API連携、通知
+
+## ライセンス
+
+MIT

--- a/ai-prompt-broadcaster/background.js
+++ b/ai-prompt-broadcaster/background.js
@@ -1,0 +1,243 @@
+const AI_SERVICES = [
+  { id: 'chatgpt', name: 'ChatGPT', url: 'https://chat.openai.com/' },
+  { id: 'claude', name: 'Claude', url: 'https://claude.ai/' },
+  { id: 'gemini', name: 'Gemini', url: 'https://gemini.google.com/' },
+  { id: 'grok', name: 'Grok', url: 'https://grok.x.ai/' }
+];
+
+const RESPONSE_TIMEOUT_MS = 120000; // 2分
+const STABILITY_DELAY_MS = 3000;   // 回答完了検知用の安定化待機
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'START_BROADCAST') {
+    startBroadcast(message.prompt)
+      .then((result) => sendResponse({ success: true, ...result }))
+      .catch((err) => sendResponse({ success: false, error: err.message }));
+    return true;
+  }
+  if (message.type === 'RETRY_SAVE') {
+    retryObsidianSave(message.prompt, message.results, message.folderPath)
+      .then((saved) => sendResponse({ success: saved }))
+      .catch((err) => sendResponse({ success: false, error: err.message }));
+    return true;
+  }
+});
+
+async function startBroadcast(prompt) {
+  const config = await getConfig();
+  const results = {};
+  const openedTabs = [];
+
+  try {
+    for (const service of AI_SERVICES) {
+      const responsePromise = waitForResponse(service.id);
+      const tab = await openAndProcessTab(service, prompt, config);
+      if (tab) openedTabs.push(tab);
+
+      const response = await responsePromise;
+      results[service.id] = {
+        name: service.name,
+        content: response?.content || null,
+        error: response?.error || null
+      };
+
+      if (tab?.id) {
+        try { await chrome.tabs.remove(tab.id); } catch (_) {}
+      }
+    }
+
+    const folderPath = buildFolderPath(prompt, config.obsidianPath);
+    const saved = await saveToObsidian(prompt, results, folderPath, config);
+
+    if (saved) {
+      await showNotification('完了', `4つのAIの回答をObsidianに保存しました。\n${folderPath}`, 'success');
+    } else {
+      await saveToLocalFallback(prompt, results, folderPath);
+      await showNotification('Obsidian保存失敗', 'ローカルに一時保存しました。設定を確認して再送信してください。', 'error');
+    }
+
+    return { results, saved };
+  } finally {
+    for (const tab of openedTabs) {
+      try {
+        if (tab?.id) await chrome.tabs.remove(tab.id);
+      } catch (_) {}
+    }
+  }
+}
+
+async function getConfig() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get([
+      'obsidianPort', 'obsidianToken', 'obsidianPath',
+      'chatgptInputSelector', 'chatgptSubmitSelector', 'chatgptResponseSelector',
+      'claudeInputSelector', 'claudeSubmitSelector', 'claudeResponseSelector',
+      'geminiInputSelector', 'geminiSubmitSelector', 'geminiResponseSelector',
+      'grokInputSelector', 'grokSubmitSelector', 'grokResponseSelector'
+    ], (result) => {
+      resolve({
+        obsidianPort: result.obsidianPort || '27124',
+        obsidianToken: result.obsidianToken || '',
+        obsidianPath: result.obsidianPath || 'AI-Research',
+        selectors: {
+          chatgpt: {
+            input: result.chatgptInputSelector || "textarea[data-id], #prompt-textarea, textarea",
+            submit: result.chatgptSubmitSelector || "button[data-testid='send-button'], [data-testid='send-button']",
+            response: result.chatgptResponseSelector || "[data-message-author-role='assistant'] .markdown"
+          },
+          claude: {
+            input: result.claudeInputSelector || "[contenteditable='true'], .ProseMirror",
+            submit: result.claudeSubmitSelector || "button[type='submit']",
+            response: result.claudeResponseSelector || "[data-role='assistant'] .markdown"
+          },
+          gemini: {
+            input: result.geminiInputSelector || "[contenteditable='true'], textarea",
+            submit: result.geminiSubmitSelector || "button[aria-label*='Send']",
+            response: result.geminiResponseSelector || "[data-message-author-role='model'] .markdown"
+          },
+          grok: {
+            input: result.grokInputSelector || "textarea, [contenteditable='true']",
+            submit: result.grokSubmitSelector || "button[type='submit']",
+            response: result.grokResponseSelector || "[data-role='assistant'] .markdown"
+          }
+        }
+      });
+    });
+  });
+}
+
+async function openAndProcessTab(service, prompt, config) {
+  const tab = await chrome.tabs.create({ url: service.url, active: false });
+  await waitForTabLoad(tab.id);
+
+  const selectors = config.selectors[service.id] || {};
+  await chrome.tabs.sendMessage(tab.id, {
+    type: 'EXECUTE_PROMPT',
+    prompt,
+    selectors
+  });
+
+  return tab;
+}
+
+function waitForTabLoad(tabId) {
+  return new Promise((resolve) => {
+    const done = () => {
+      chrome.tabs.onUpdated.removeListener(listener);
+      setTimeout(resolve, 2500);
+    };
+    const listener = (id, info) => {
+      if (id === tabId && info.status === 'complete') done();
+    };
+    chrome.tabs.onUpdated.addListener(listener);
+    chrome.tabs.get(tabId, (tab) => {
+      if (tab?.status === 'complete') done();
+    });
+  });
+}
+
+function waitForResponse(serviceId, tabId) {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      chrome.runtime.onMessage.removeListener(handler);
+      resolve({ content: null, error: 'タイムアウト' });
+    }, RESPONSE_TIMEOUT_MS);
+
+    const handler = (msg) => {
+      if (msg.type === 'RESPONSE_READY' && msg.serviceId === serviceId) {
+        clearTimeout(timeout);
+        chrome.runtime.onMessage.removeListener(handler);
+        resolve({ content: msg.content, error: msg.error });
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(handler);
+  });
+}
+
+function buildFolderPath(prompt, basePath) {
+  const date = new Date().toISOString().slice(0, 10);
+  const prefix = prompt.slice(0, 20).replace(/[/\\?%*:|"<>]/g, '_').trim();
+  return `${basePath}/${date}_${prefix}`;
+}
+
+async function saveToObsidian(prompt, results, folderPath, config) {
+  const baseUrl = `http://127.0.0.1:${config.obsidianPort}`;
+
+  const files = [
+    { path: `${folderPath}/question.md`, content: `# 質問\n\n${prompt}` },
+    { path: `${folderPath}/ChatGPT.md`, content: formatResponse('ChatGPT', results.chatgpt?.content) },
+    { path: `${folderPath}/Claude.md`, content: formatResponse('Claude', results.claude?.content) },
+    { path: `${folderPath}/Gemini.md`, content: formatResponse('Gemini', results.gemini?.content) },
+    { path: `${folderPath}/Grok.md`, content: formatResponse('Grok', results.grok?.content) },
+    { path: `${folderPath}/Summary.md`, content: buildSummary(prompt, results) }
+  ];
+
+  try {
+    for (const file of files) {
+      const encodedPath = file.path.split('/').map(encodeURIComponent).join('/');
+      const res = await fetch(`${baseUrl}/vault/${encodedPath}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          ...(config.obsidianToken && { 'Authorization': `Bearer ${config.obsidianToken}` })
+        },
+        body: file.content
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${file.path}`);
+    }
+    return true;
+  } catch (err) {
+    console.error('Obsidian save error:', err);
+    return false;
+  }
+}
+
+function formatResponse(name, content) {
+  if (!content) return `# ${name}\n\n（取得できませんでした）\n`;
+  return `# ${name}\n\n${content}\n`;
+}
+
+function buildSummary(prompt, results) {
+  const parts = ['# まとめ\n\n', `## 質問\n\n${prompt}\n\n`, '## 各AIの回答\n\n'];
+  for (const [id, data] of Object.entries(results)) {
+    const name = data?.name || id;
+    const content = data?.content || '（取得できませんでした）';
+    parts.push(`### ${name}\n\n${content}\n\n---\n\n`);
+  }
+  return parts.join('');
+}
+
+async function saveToLocalFallback(prompt, results, folderPath) {
+  const pending = {
+    prompt,
+    results,
+    folderPath,
+    timestamp: Date.now()
+  };
+  const { pendingSaves = [] } = await chrome.storage.local.get('pendingSaves');
+  pendingSaves.push(pending);
+  await chrome.storage.local.set({ pendingSaves });
+}
+
+async function retryObsidianSave(prompt, results, folderPath) {
+  const config = await getConfig();
+  const saved = await saveToObsidian(prompt, results, folderPath, config);
+  if (saved) {
+    const { pendingSaves = [] } = await chrome.storage.local.get('pendingSaves');
+    const filtered = pendingSaves.filter(p => !(p.folderPath === folderPath && p.prompt === prompt));
+    await chrome.storage.local.set({ pendingSaves: filtered });
+    await showNotification('再送信完了', `Obsidianに保存しました。\n${folderPath}`, 'success');
+  }
+  return saved;
+}
+
+async function showNotification(title, message, type) {
+  const options = {
+    type: 'basic',
+    iconUrl: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%236366f1"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>',
+    title,
+    message
+  };
+  await chrome.notifications.create(options);
+}

--- a/ai-prompt-broadcaster/content-chatgpt.js
+++ b/ai-prompt-broadcaster/content-chatgpt.js
@@ -1,0 +1,107 @@
+(function () {
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.type !== 'EXECUTE_PROMPT') return;
+    executePrompt(msg.prompt, msg.selectors || {}).then(sendResponse);
+    return true;
+  });
+
+  async function executePrompt(prompt, selectors) {
+    const inputSel = selectors.input || "textarea[data-id], #prompt-textarea, textarea";
+    const submitSel = selectors.submit || "button[data-testid='send-button'], [data-testid='send-button'], button[aria-label*='Send']";
+    const responseSel = selectors.response || "[data-message-author-role='assistant'] .markdown, [data-message-author-role='assistant'], .markdown";
+
+    try {
+      const input = findElement(inputSel);
+      if (!input) throw new Error('入力欄が見つかりません');
+
+      await setInputValue(input, prompt);
+      await sleep(300);
+
+      const submitBtn = findElement(submitSel);
+      if (!submitBtn) throw new Error('送信ボタンが見つかりません');
+      submitBtn.click();
+
+      const content = await waitForResponse(responseSel);
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'chatgpt', content });
+    } catch (err) {
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'chatgpt', content: null, error: err.message });
+    }
+  }
+
+  function findElement(selectorStr) {
+    const selectors = selectorStr.split(',').map(s => s.trim());
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function setInputValue(el, value) {
+    if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
+      el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    } else if (el.isContentEditable) {
+      el.focus();
+      document.execCommand('selectAll', false, null);
+      document.execCommand('insertText', false, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
+  function waitForResponse(selectorStr, maxWait = 120000) {
+    return new Promise((resolve) => {
+      const selectors = selectorStr.split(',').map(s => s.trim());
+      let lastChange = Date.now();
+      const stabilityMs = 3000;
+
+      const extract = () => {
+        for (const sel of selectors) {
+          const els = document.querySelectorAll(sel);
+          const last = els[els.length - 1];
+          if (last) {
+            const text = last.innerText || last.textContent || '';
+            if (text.trim().length > 10) return text.trim();
+          }
+        }
+        return null;
+      };
+
+      const check = () => {
+        const text = extract();
+        if (text) {
+          const now = Date.now();
+          if (now - lastChange > stabilityMs) {
+            resolve(text);
+            return true;
+          }
+        } else {
+          lastChange = Date.now();
+        }
+        return false;
+      };
+
+      const observer = new MutationObserver(() => {
+        if (check()) observer.disconnect();
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+      const interval = setInterval(() => {
+        if (check()) {
+          clearInterval(interval);
+          observer.disconnect();
+        }
+      }, 500);
+
+      setTimeout(() => {
+        clearInterval(interval);
+        observer.disconnect();
+        resolve(extract() || '');
+      }, maxWait);
+    });
+  }
+
+  function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms));
+  }
+})();

--- a/ai-prompt-broadcaster/content-claude.js
+++ b/ai-prompt-broadcaster/content-claude.js
@@ -1,0 +1,107 @@
+(function () {
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.type !== 'EXECUTE_PROMPT') return;
+    executePrompt(msg.prompt, msg.selectors || {}).then(sendResponse);
+    return true;
+  });
+
+  async function executePrompt(prompt, selectors) {
+    const inputSel = selectors.input || "[contenteditable='true'][data-placeholder], .ProseMirror, [contenteditable='true']";
+    const submitSel = selectors.submit || "button[type='submit'], [aria-label='Send message']";
+    const responseSel = selectors.response || "[data-role='assistant'] .markdown, [data-role='assistant'], .markdown";
+
+    try {
+      const input = findElement(inputSel);
+      if (!input) throw new Error('入力欄が見つかりません');
+
+      await setInputValue(input, prompt);
+      await sleep(300);
+
+      const submitBtn = findElement(submitSel);
+      if (!submitBtn) throw new Error('送信ボタンが見つかりません');
+      submitBtn.click();
+
+      const content = await waitForResponse(responseSel);
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'claude', content });
+    } catch (err) {
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'claude', content: null, error: err.message });
+    }
+  }
+
+  function findElement(selectorStr) {
+    const selectors = selectorStr.split(',').map(s => s.trim());
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function setInputValue(el, value) {
+    if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
+      el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    } else if (el.isContentEditable) {
+      el.focus();
+      document.execCommand('selectAll', false, null);
+      document.execCommand('insertText', false, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
+  function waitForResponse(selectorStr, maxWait = 120000) {
+    return new Promise((resolve) => {
+      const selectors = selectorStr.split(',').map(s => s.trim());
+      let lastChange = Date.now();
+      const stabilityMs = 3000;
+
+      const extract = () => {
+        for (const sel of selectors) {
+          const els = document.querySelectorAll(sel);
+          const last = els[els.length - 1];
+          if (last) {
+            const text = last.innerText || last.textContent || '';
+            if (text.trim().length > 10) return text.trim();
+          }
+        }
+        return null;
+      };
+
+      const check = () => {
+        const text = extract();
+        if (text) {
+          const now = Date.now();
+          if (now - lastChange > stabilityMs) {
+            resolve(text);
+            return true;
+          }
+        } else {
+          lastChange = Date.now();
+        }
+        return false;
+      };
+
+      const observer = new MutationObserver(() => {
+        if (check()) observer.disconnect();
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+      const interval = setInterval(() => {
+        if (check()) {
+          clearInterval(interval);
+          observer.disconnect();
+        }
+      }, 500);
+
+      setTimeout(() => {
+        clearInterval(interval);
+        observer.disconnect();
+        resolve(extract() || '');
+      }, maxWait);
+    });
+  }
+
+  function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms));
+  }
+})();

--- a/ai-prompt-broadcaster/content-gemini.js
+++ b/ai-prompt-broadcaster/content-gemini.js
@@ -1,0 +1,107 @@
+(function () {
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.type !== 'EXECUTE_PROMPT') return;
+    executePrompt(msg.prompt, msg.selectors || {}).then(sendResponse);
+    return true;
+  });
+
+  async function executePrompt(prompt, selectors) {
+    const inputSel = selectors.input || "[contenteditable='true'], textarea, .ql-editor";
+    const submitSel = selectors.submit || "button[aria-label*='Send'], button.send";
+    const responseSel = selectors.response || "[data-message-author-role='model'], .model-response .markdown, .markdown";
+
+    try {
+      const input = findElement(inputSel);
+      if (!input) throw new Error('入力欄が見つかりません');
+
+      await setInputValue(input, prompt);
+      await sleep(300);
+
+      const submitBtn = findElement(submitSel);
+      if (!submitBtn) throw new Error('送信ボタンが見つかりません');
+      submitBtn.click();
+
+      const content = await waitForResponse(responseSel);
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'gemini', content });
+    } catch (err) {
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'gemini', content: null, error: err.message });
+    }
+  }
+
+  function findElement(selectorStr) {
+    const selectors = selectorStr.split(',').map(s => s.trim());
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function setInputValue(el, value) {
+    if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
+      el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    } else if (el.isContentEditable) {
+      el.focus();
+      document.execCommand('selectAll', false, null);
+      document.execCommand('insertText', false, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
+  function waitForResponse(selectorStr, maxWait = 120000) {
+    return new Promise((resolve) => {
+      const selectors = selectorStr.split(',').map(s => s.trim());
+      let lastChange = Date.now();
+      const stabilityMs = 3000;
+
+      const extract = () => {
+        for (const sel of selectors) {
+          const els = document.querySelectorAll(sel);
+          const last = els[els.length - 1];
+          if (last) {
+            const text = last.innerText || last.textContent || '';
+            if (text.trim().length > 10) return text.trim();
+          }
+        }
+        return null;
+      };
+
+      const check = () => {
+        const text = extract();
+        if (text) {
+          const now = Date.now();
+          if (now - lastChange > stabilityMs) {
+            resolve(text);
+            return true;
+          }
+        } else {
+          lastChange = Date.now();
+        }
+        return false;
+      };
+
+      const observer = new MutationObserver(() => {
+        if (check()) observer.disconnect();
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+      const interval = setInterval(() => {
+        if (check()) {
+          clearInterval(interval);
+          observer.disconnect();
+        }
+      }, 500);
+
+      setTimeout(() => {
+        clearInterval(interval);
+        observer.disconnect();
+        resolve(extract() || '');
+      }, maxWait);
+    });
+  }
+
+  function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms));
+  }
+})();

--- a/ai-prompt-broadcaster/content-grok.js
+++ b/ai-prompt-broadcaster/content-grok.js
@@ -1,0 +1,107 @@
+(function () {
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    if (msg.type !== 'EXECUTE_PROMPT') return;
+    executePrompt(msg.prompt, msg.selectors || {}).then(sendResponse);
+    return true;
+  });
+
+  async function executePrompt(prompt, selectors) {
+    const inputSel = selectors.input || "textarea, [contenteditable='true']";
+    const submitSel = selectors.submit || "button[type='submit'], button.send";
+    const responseSel = selectors.response || "[data-role='assistant'], .response-content, .markdown";
+
+    try {
+      const input = findElement(inputSel);
+      if (!input) throw new Error('入力欄が見つかりません');
+
+      await setInputValue(input, prompt);
+      await sleep(300);
+
+      const submitBtn = findElement(submitSel);
+      if (!submitBtn) throw new Error('送信ボタンが見つかりません');
+      submitBtn.click();
+
+      const content = await waitForResponse(responseSel);
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'grok', content });
+    } catch (err) {
+      chrome.runtime.sendMessage({ type: 'RESPONSE_READY', serviceId: 'grok', content: null, error: err.message });
+    }
+  }
+
+  function findElement(selectorStr) {
+    const selectors = selectorStr.split(',').map(s => s.trim());
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function setInputValue(el, value) {
+    if (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT') {
+      el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    } else if (el.isContentEditable) {
+      el.focus();
+      document.execCommand('selectAll', false, null);
+      document.execCommand('insertText', false, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+
+  function waitForResponse(selectorStr, maxWait = 120000) {
+    return new Promise((resolve) => {
+      const selectors = selectorStr.split(',').map(s => s.trim());
+      let lastChange = Date.now();
+      const stabilityMs = 3000;
+
+      const extract = () => {
+        for (const sel of selectors) {
+          const els = document.querySelectorAll(sel);
+          const last = els[els.length - 1];
+          if (last) {
+            const text = last.innerText || last.textContent || '';
+            if (text.trim().length > 10) return text.trim();
+          }
+        }
+        return null;
+      };
+
+      const check = () => {
+        const text = extract();
+        if (text) {
+          const now = Date.now();
+          if (now - lastChange > stabilityMs) {
+            resolve(text);
+            return true;
+          }
+        } else {
+          lastChange = Date.now();
+        }
+        return false;
+      };
+
+      const observer = new MutationObserver(() => {
+        if (check()) observer.disconnect();
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+      const interval = setInterval(() => {
+        if (check()) {
+          clearInterval(interval);
+          observer.disconnect();
+        }
+      }, 500);
+
+      setTimeout(() => {
+        clearInterval(interval);
+        observer.disconnect();
+        resolve(extract() || '');
+      }, maxWait);
+    });
+  }
+
+  function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms));
+  }
+})();

--- a/ai-prompt-broadcaster/manifest.json
+++ b/ai-prompt-broadcaster/manifest.json
@@ -1,0 +1,50 @@
+{
+  "manifest_version": 3,
+  "name": "AI一括質問＆Obsidian保存ツール",
+  "version": "1.0.0",
+  "description": "プロンプトを4つのAIサービスに順次送信し、回答をObsidianに保存するChrome拡張",
+  "permissions": [
+    "storage",
+    "tabs",
+    "scripting",
+    "notifications",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "https://chat.openai.com/*",
+    "https://claude.ai/*",
+    "https://gemini.google.com/*",
+    "https://*.x.ai/*",
+    "http://localhost/*",
+    "http://127.0.0.1/*"
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["content-chatgpt.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://claude.ai/*"],
+      "js": ["content-claude.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://gemini.google.com/*"],
+      "js": ["content-gemini.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://*.x.ai/*", "https://grok.x.ai/*"],
+      "js": ["content-grok.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/ai-prompt-broadcaster/options.css
+++ b/ai-prompt-broadcaster/options.css
@@ -1,0 +1,214 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #1a1a2e;
+  background: #f8f9fc;
+  padding: 40px 20px;
+}
+
+.container {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.header {
+  margin-bottom: 32px;
+}
+
+.header h1 {
+  font-size: 24px;
+  font-weight: 700;
+  color: #16213e;
+  margin-bottom: 8px;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.section {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.section h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 8px;
+}
+
+.section-desc {
+  font-size: 13px;
+  color: #6b7280;
+  margin-bottom: 20px;
+}
+
+.selector-group {
+  margin-bottom: 24px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.selector-group:last-of-type {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.selector-group h3 {
+  font-size: 15px;
+  font-weight: 600;
+  color: #4f46e5;
+  margin-bottom: 16px;
+}
+
+.form-group {
+  margin-bottom: 16px;
+}
+
+.form-group:last-child {
+  margin-bottom: 0;
+}
+
+.form-group label {
+  display: block;
+  font-weight: 600;
+  color: #374151;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.form-group small {
+  display: block;
+  font-size: 12px;
+  color: #9ca3af;
+  margin-top: 4px;
+}
+
+input[type="text"],
+input[type="number"],
+input[type="password"] {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: 'Consolas', 'Monaco', monospace;
+}
+
+input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.btn {
+  padding: 12px 24px;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+  color: white;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
+}
+
+.btn-secondary {
+  background: #f3f4f6;
+  color: #4b5563;
+  border: 1px solid #e5e7eb;
+}
+
+.btn-secondary:hover {
+  background: #e5e7eb;
+}
+
+.status {
+  margin-top: 20px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.status.success {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.status.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.pending-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pending-item {
+  padding: 12px 16px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.pending-item .prompt-preview {
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 4px;
+}
+
+.pending-item .meta {
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 8px;
+}
+
+.pending-item .btn-retry {
+  padding: 6px 12px;
+  font-size: 12px;
+  background: #6366f1;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.pending-item .btn-retry:hover {
+  background: #4f46e5;
+}
+
+.pending-empty {
+  padding: 16px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 13px;
+}

--- a/ai-prompt-broadcaster/options.html
+++ b/ai-prompt-broadcaster/options.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI一括質問 - 設定</title>
+  <link rel="stylesheet" href="options.css">
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      <h1>AI一括質問＆Obsidian保存 - 設定</h1>
+      <p class="subtitle">Obsidian Local REST APIとDOMセレクタを設定します</p>
+    </header>
+
+    <form id="optionsForm">
+      <section class="section">
+        <h2>Obsidian Local REST API</h2>
+        <p class="section-desc">Obsidianの「Local REST API」プラグインをインストール・有効化し、以下を設定してください。</p>
+
+        <div class="form-group">
+          <label for="obsidianPort">ポート番号</label>
+          <input type="number" id="obsidianPort" placeholder="27124" min="1" max="65535">
+        </div>
+
+        <div class="form-group">
+          <label for="obsidianToken">APIキー（Bearer トークン）</label>
+          <input type="password" id="obsidianToken" placeholder="あなたのAPIキー">
+        </div>
+
+        <div class="form-group">
+          <label for="obsidianPath">保存先ベースパス</label>
+          <input type="text" id="obsidianPath" placeholder="AI-Research">
+          <small>例: AI-Research （日付と質問からサブフォルダが自動作成されます）</small>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>DOMセレクタ（上級者向け）</h2>
+        <p class="section-desc">AIサービスのUI変更で動作しなくなった場合、セレクタを調整できます。通常はデフォルトのままで問題ありません。</p>
+
+        <div class="selector-group">
+          <h3>ChatGPT</h3>
+          <div class="form-group">
+            <label>入力欄セレクタ（カンマ区切りで複数指定可）</label>
+            <input type="text" id="chatgptInputSelector" placeholder="textarea[data-id], #prompt-textarea">
+          </div>
+          <div class="form-group">
+            <label>送信ボタンセレクタ</label>
+            <input type="text" id="chatgptSubmitSelector" placeholder="button[data-testid='send-button'], [data-testid='send-button']">
+          </div>
+          <div class="form-group">
+            <label>回答エリアセレクタ</label>
+            <input type="text" id="chatgptResponseSelector" placeholder="[data-message-author-role='assistant'], .markdown">
+          </div>
+        </div>
+
+        <div class="selector-group">
+          <h3>Claude</h3>
+          <div class="form-group">
+            <label>入力欄セレクタ</label>
+            <input type="text" id="claudeInputSelector" placeholder="[contenteditable='true'], .ProseMirror">
+          </div>
+          <div class="form-group">
+            <label>送信ボタンセレクタ</label>
+            <input type="text" id="claudeSubmitSelector" placeholder="button[type='submit'], [aria-label='Send']">
+          </div>
+          <div class="form-group">
+            <label>回答エリアセレクタ</label>
+            <input type="text" id="claudeResponseSelector" placeholder="[data-role='assistant'], .markdown">
+          </div>
+        </div>
+
+        <div class="selector-group">
+          <h3>Gemini</h3>
+          <div class="form-group">
+            <label>入力欄セレクタ</label>
+            <input type="text" id="geminiInputSelector" placeholder="[contenteditable='true'], textarea, .ql-editor">
+          </div>
+          <div class="form-group">
+            <label>送信ボタンセレクタ</label>
+            <input type="text" id="geminiSubmitSelector" placeholder="button[aria-label='Send'], button.send">
+          </div>
+          <div class="form-group">
+            <label>回答エリアセレクタ</label>
+            <input type="text" id="geminiResponseSelector" placeholder="[data-message-author-role='model'], .markdown">
+          </div>
+        </div>
+
+        <div class="selector-group">
+          <h3>Grok</h3>
+          <div class="form-group">
+            <label>入力欄セレクタ</label>
+            <input type="text" id="grokInputSelector" placeholder="textarea, [contenteditable='true']">
+          </div>
+          <div class="form-group">
+            <label>送信ボタンセレクタ</label>
+            <input type="text" id="grokSubmitSelector" placeholder="button[type='submit'], button.send">
+          </div>
+          <div class="form-group">
+            <label>回答エリアセレクタ</label>
+            <input type="text" id="grokResponseSelector" placeholder="[data-role='assistant'], .response-content">
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>保存に失敗したデータ</h2>
+        <p class="section-desc">Obsidianが起動していない場合などにローカルに一時保存されたデータです。設定を確認後、再送信できます。</p>
+        <div id="pendingSaves" class="pending-list"></div>
+      </section>
+
+      <div class="actions">
+        <button type="submit" class="btn btn-primary">保存</button>
+        <button type="button" id="resetSelectors" class="btn btn-secondary">セレクタをデフォルトに戻す</button>
+      </div>
+    </form>
+
+    <div id="saveStatus" class="status" hidden></div>
+  </div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/ai-prompt-broadcaster/options.js
+++ b/ai-prompt-broadcaster/options.js
@@ -1,0 +1,169 @@
+const DEFAULT_SELECTORS = {
+  chatgpt: {
+    input: "textarea[data-id], #prompt-textarea, textarea",
+    submit: "button[data-testid='send-button'], [data-testid='send-button'], button[aria-label*='Send']",
+    response: "[data-message-author-role='assistant'] .markdown, [data-message-author-role='assistant'], .markdown"
+  },
+  claude: {
+    input: "[contenteditable='true'][data-placeholder], .ProseMirror, [contenteditable='true']",
+    submit: "button[type='submit'], [aria-label='Send message']",
+    response: "[data-role='assistant'] .markdown, [data-role='assistant'], .markdown"
+  },
+  gemini: {
+    input: "[contenteditable='true'], textarea, .ql-editor",
+    submit: "button[aria-label*='Send'], button.send",
+    response: "[data-message-author-role='model'], .model-response .markdown, .markdown"
+  },
+  grok: {
+    input: "textarea, [contenteditable='true']",
+    submit: "button[type='submit'], button.send",
+    response: "[data-role='assistant'], .response-content, .markdown"
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadOptions();
+  loadPendingSaves();
+
+  document.getElementById('optionsForm').addEventListener('submit', (e) => {
+    e.preventDefault();
+    saveOptions();
+  });
+
+  document.getElementById('resetSelectors').addEventListener('click', () => {
+    resetSelectors();
+  });
+});
+
+async function loadPendingSaves() {
+  const { pendingSaves = [] } = await chrome.storage.local.get('pendingSaves');
+  const container = document.getElementById('pendingSaves');
+  if (pendingSaves.length === 0) {
+    container.innerHTML = '<div class="pending-empty">保存に失敗したデータはありません</div>';
+    return;
+  }
+  container.innerHTML = pendingSaves.map((item, i) => `
+    <div class="pending-item" data-index="${i}">
+      <div class="prompt-preview">${escapeHtml(item.prompt?.slice(0, 50) || '')}${(item.prompt?.length || 0) > 50 ? '...' : ''}</div>
+      <div class="meta">${item.folderPath || ''} · ${new Date(item.timestamp).toLocaleString('ja-JP')}</div>
+      <button type="button" class="btn-retry" data-index="${i}">Obsidianに再送信</button>
+    </div>
+  `).join('');
+  container.querySelectorAll('.btn-retry').forEach(btn => {
+    btn.addEventListener('click', () => retrySave(parseInt(btn.dataset.index)));
+  });
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+async function retrySave(index) {
+  const { pendingSaves = [] } = await chrome.storage.local.get('pendingSaves');
+  const item = pendingSaves[index];
+  if (!item) return;
+  showStatus('再送信を開始しました...', 'success');
+  chrome.runtime.sendMessage({
+    type: 'RETRY_SAVE',
+    prompt: item.prompt,
+    results: item.results,
+    folderPath: item.folderPath,
+    index
+  }, async (response) => {
+    if (response?.success) {
+      pendingSaves.splice(index, 1);
+      await chrome.storage.local.set({ pendingSaves });
+      loadPendingSaves();
+      showStatus('Obsidianに保存しました。', 'success');
+    } else {
+      showStatus(response?.error || '保存に失敗しました。', 'error');
+    }
+  });
+}
+
+function loadOptions() {
+  chrome.storage.sync.get([
+    'obsidianPort', 'obsidianToken', 'obsidianPath',
+    'chatgptInputSelector', 'chatgptSubmitSelector', 'chatgptResponseSelector',
+    'claudeInputSelector', 'claudeSubmitSelector', 'claudeResponseSelector',
+    'geminiInputSelector', 'geminiSubmitSelector', 'geminiResponseSelector',
+    'grokInputSelector', 'grokSubmitSelector', 'grokResponseSelector'
+  ], (result) => {
+    document.getElementById('obsidianPort').value = result.obsidianPort || '27124';
+    document.getElementById('obsidianToken').value = result.obsidianToken || '';
+    document.getElementById('obsidianPath').value = result.obsidianPath || 'AI-Research';
+
+    document.getElementById('chatgptInputSelector').value = result.chatgptInputSelector || DEFAULT_SELECTORS.chatgpt.input;
+    document.getElementById('chatgptSubmitSelector').value = result.chatgptSubmitSelector || DEFAULT_SELECTORS.chatgpt.submit;
+    document.getElementById('chatgptResponseSelector').value = result.chatgptResponseSelector || DEFAULT_SELECTORS.chatgpt.response;
+
+    document.getElementById('claudeInputSelector').value = result.claudeInputSelector || DEFAULT_SELECTORS.claude.input;
+    document.getElementById('claudeSubmitSelector').value = result.claudeSubmitSelector || DEFAULT_SELECTORS.claude.submit;
+    document.getElementById('claudeResponseSelector').value = result.claudeResponseSelector || DEFAULT_SELECTORS.claude.response;
+
+    document.getElementById('geminiInputSelector').value = result.geminiInputSelector || DEFAULT_SELECTORS.gemini.input;
+    document.getElementById('geminiSubmitSelector').value = result.geminiSubmitSelector || DEFAULT_SELECTORS.gemini.submit;
+    document.getElementById('geminiResponseSelector').value = result.geminiResponseSelector || DEFAULT_SELECTORS.gemini.response;
+
+    document.getElementById('grokInputSelector').value = result.grokInputSelector || DEFAULT_SELECTORS.grok.input;
+    document.getElementById('grokSubmitSelector').value = result.grokSubmitSelector || DEFAULT_SELECTORS.grok.submit;
+    document.getElementById('grokResponseSelector').value = result.grokResponseSelector || DEFAULT_SELECTORS.grok.response;
+  });
+}
+
+function saveOptions() {
+  const options = {
+    obsidianPort: document.getElementById('obsidianPort').value || '27124',
+    obsidianToken: document.getElementById('obsidianToken').value,
+    obsidianPath: document.getElementById('obsidianPath').value.trim() || 'AI-Research',
+    chatgptInputSelector: document.getElementById('chatgptInputSelector').value.trim(),
+    chatgptSubmitSelector: document.getElementById('chatgptSubmitSelector').value.trim(),
+    chatgptResponseSelector: document.getElementById('chatgptResponseSelector').value.trim(),
+    claudeInputSelector: document.getElementById('claudeInputSelector').value.trim(),
+    claudeSubmitSelector: document.getElementById('claudeSubmitSelector').value.trim(),
+    claudeResponseSelector: document.getElementById('claudeResponseSelector').value.trim(),
+    geminiInputSelector: document.getElementById('geminiInputSelector').value.trim(),
+    geminiSubmitSelector: document.getElementById('geminiSubmitSelector').value.trim(),
+    geminiResponseSelector: document.getElementById('geminiResponseSelector').value.trim(),
+    grokInputSelector: document.getElementById('grokInputSelector').value.trim(),
+    grokSubmitSelector: document.getElementById('grokSubmitSelector').value.trim(),
+    grokResponseSelector: document.getElementById('grokResponseSelector').value.trim()
+  };
+
+  chrome.storage.sync.set(options, () => {
+    showStatus('設定を保存しました。', 'success');
+  });
+}
+
+function resetSelectors() {
+  document.getElementById('chatgptInputSelector').value = DEFAULT_SELECTORS.chatgpt.input;
+  document.getElementById('chatgptSubmitSelector').value = DEFAULT_SELECTORS.chatgpt.submit;
+  document.getElementById('chatgptResponseSelector').value = DEFAULT_SELECTORS.chatgpt.response;
+
+  document.getElementById('claudeInputSelector').value = DEFAULT_SELECTORS.claude.input;
+  document.getElementById('claudeSubmitSelector').value = DEFAULT_SELECTORS.claude.submit;
+  document.getElementById('claudeResponseSelector').value = DEFAULT_SELECTORS.claude.response;
+
+  document.getElementById('geminiInputSelector').value = DEFAULT_SELECTORS.gemini.input;
+  document.getElementById('geminiSubmitSelector').value = DEFAULT_SELECTORS.gemini.submit;
+  document.getElementById('geminiResponseSelector').value = DEFAULT_SELECTORS.gemini.response;
+
+  document.getElementById('grokInputSelector').value = DEFAULT_SELECTORS.grok.input;
+  document.getElementById('grokSubmitSelector').value = DEFAULT_SELECTORS.grok.submit;
+  document.getElementById('grokResponseSelector').value = DEFAULT_SELECTORS.grok.response;
+
+  showStatus('セレクタをデフォルトに戻しました。保存ボタンで確定してください。', 'success');
+}
+
+function showStatus(message, type) {
+  const statusEl = document.getElementById('saveStatus');
+  statusEl.textContent = message;
+  statusEl.className = 'status ' + type;
+  statusEl.hidden = false;
+
+  setTimeout(() => {
+    statusEl.hidden = true;
+  }, 3000);
+}

--- a/ai-prompt-broadcaster/popup.css
+++ b/ai-prompt-broadcaster/popup.css
@@ -1,0 +1,177 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #1a1a2e;
+  background: linear-gradient(135deg, #f8f9fc 0%, #eef1f7 100%);
+  min-width: 380px;
+  max-width: 420px;
+}
+
+.container {
+  padding: 20px;
+}
+
+.header {
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.header h1 {
+  font-size: 20px;
+  font-weight: 700;
+  color: #16213e;
+  margin-bottom: 4px;
+}
+
+.subtitle {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-weight: 600;
+  color: #374151;
+  font-size: 13px;
+}
+
+textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 14px;
+  resize: vertical;
+  min-height: 100px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+textarea:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+textarea::placeholder {
+  color: #9ca3af;
+}
+
+.services-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(99, 102, 241, 0.08);
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.services-label {
+  font-weight: 600;
+  color: #4f46e5;
+}
+
+.services-list {
+  color: #6b7280;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn-primary {
+  flex: 1;
+  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+  color: white;
+  box-shadow: 0 2px 4px rgba(99, 102, 241, 0.3);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #4f46e5 0%, #4338ca 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(99, 102, 241, 0.35);
+}
+
+.btn-primary:disabled {
+  opacity: 0.8;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: #f3f4f6;
+  color: #4b5563;
+  border: 1px solid #e5e7eb;
+}
+
+.btn-secondary:hover {
+  background: #e5e7eb;
+}
+
+.status {
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.status.info {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.status.success {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.status.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.btn-loading {
+  display: none;
+}
+
+.btn.loading .btn-text {
+  display: none;
+}
+
+.btn.loading .btn-loading {
+  display: inline;
+}

--- a/ai-prompt-broadcaster/popup.html
+++ b/ai-prompt-broadcaster/popup.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI一括質問</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      <h1>AI一括質問</h1>
+      <p class="subtitle">4つのAIに質問を送信し、Obsidianに保存</p>
+    </header>
+
+    <main class="main">
+      <div class="form-group">
+        <label for="prompt">質問（プロンプト）</label>
+        <textarea id="prompt" rows="5" placeholder="AIに聞きたいことを入力してください..."></textarea>
+      </div>
+
+      <div class="services-info">
+        <span class="services-label">送信先:</span>
+        <span class="services-list">ChatGPT → Claude → Gemini → Grok</span>
+      </div>
+
+      <div class="actions">
+        <button id="submit" class="btn btn-primary">
+          <span class="btn-text">送信して保存</span>
+          <span class="btn-loading" hidden>処理中...</span>
+        </button>
+        <a href="options.html" target="_blank" class="btn btn-secondary">設定</a>
+      </div>
+
+      <div id="status" class="status" hidden></div>
+    </main>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/ai-prompt-broadcaster/popup.js
+++ b/ai-prompt-broadcaster/popup.js
@@ -1,0 +1,70 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const promptInput = document.getElementById('prompt');
+  const submitBtn = document.getElementById('submit');
+  const statusEl = document.getElementById('status');
+
+  // 保存されたプロンプトを復元
+  chrome.storage.local.get(['lastPrompt'], (result) => {
+    if (result.lastPrompt) {
+      promptInput.value = result.lastPrompt;
+    }
+  });
+
+  submitBtn.addEventListener('click', async () => {
+    const prompt = promptInput.value.trim();
+    if (!prompt) {
+      showStatus('質問を入力してください。', 'error');
+      return;
+    }
+
+    // 設定を確認
+    const { obsidianPort, obsidianPath } = await chrome.storage.sync.get(['obsidianPort', 'obsidianPath']);
+    if (!obsidianPort || !obsidianPath) {
+      showStatus('設定画面でObsidian APIの設定を行ってください。', 'error');
+      return;
+    }
+
+    // プロンプトを一時保存
+    chrome.storage.local.set({ lastPrompt: prompt });
+
+    setLoading(true);
+    hideStatus();
+
+    try {
+      // Background Workerにメッセージを送信
+      chrome.runtime.sendMessage({
+        type: 'START_BROADCAST',
+        prompt
+      }, (response) => {
+        setLoading(false);
+        if (chrome.runtime.lastError) {
+          showStatus('エラー: ' + chrome.runtime.lastError.message, 'error');
+          return;
+        }
+        if (response?.success) {
+          showStatus('処理を開始しました。完了時に通知されます。', 'info');
+        } else {
+          showStatus(response?.error || '処理の開始に失敗しました。', 'error');
+        }
+      });
+    } catch (err) {
+      setLoading(false);
+      showStatus('エラー: ' + err.message, 'error');
+    }
+  });
+
+  function setLoading(loading) {
+    submitBtn.disabled = loading;
+    submitBtn.classList.toggle('loading', loading);
+  }
+
+  function showStatus(message, type) {
+    statusEl.textContent = message;
+    statusEl.className = 'status ' + type;
+    statusEl.hidden = false;
+  }
+
+  function hideStatus() {
+    statusEl.hidden = true;
+  }
+});


### PR DESCRIPTION
Implement the Chrome extension "AI一括質問＆Obsidian保存ツール" to send prompts to multiple AI services and save aggregated responses to Obsidian.

---
<p><a href="https://cursor.com/agents/bc-f76a823f-6c8d-4275-acb4-9916153160c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f76a823f-6c8d-4275-acb4-9916153160c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

