### PR TITLE
Claude・Geminiの送信ボタンセレクタを更新し、UI変更に対応

### DIFF
--- a/ai-prompt-broadcaster/content-claude.js
+++ b/ai-prompt-broadcaster/content-claude.js
@@ -2,7 +2,7 @@
   const defaultConfig = {
     inputSelector:
       "div[data-testid='chat-input'], div.tiptap.ProseMirror[contenteditable='true'], .ProseMirror[contenteditable='true']",
-    submitButtonSelector: "button[class*='Button_claude'], div.shrink-0 button[aria-label]",
+    submitButtonSelector: "button[class*='Button_claude'], div.shrink-0 button[aria-label], button[aria-label*='Send'], button[aria-label*='送信'], [data-testid='send-button'], button[data-testid*='send'], form button[type='submit'], button[type='submit']",
     answerContainerSelector: "[data-testid='conversation-thread'], main, [class*='message']",
     copyButtonSelector: "[data-testid='action-bar-copy'], button[aria-label='Copy']",
     doneCheckSelector: "[data-testid='stop-button'], button[aria-label='Stop']",

--- a/ai-prompt-broadcaster/content-gemini.js
+++ b/ai-prompt-broadcaster/content-gemini.js
@@ -3,7 +3,7 @@
     inputSelector:
       "rich-textarea div[contenteditable='true'], div.ql-editor[contenteditable='true'], div[contenteditable='true'], textarea",
     submitButtonSelector:
-      "button.send-button, button[aria-label='Send message'], button[mat-icon-button], button[type='submit']",
+      "button.send-button, button[aria-label='Send message'], button[aria-label*='Send'], button[aria-label*='送信'], button[mat-icon-button], button[mat-icon-button][aria-label], [aria-label='Send message'], button[type='submit'], [data-testid*='send']",
     answerContainerSelector: "main, [data-model-id]",
     copyButtonSelector: "button[aria-label='Copy'], [aria-label*='Copy']",
     doneCheckSelector: "button[aria-label='Stop'], mat-icon[data-mat-icon-name='stop_circle']",

--- a/ai-prompt-broadcaster/content-utils.js
+++ b/ai-prompt-broadcaster/content-utils.js
@@ -214,20 +214,43 @@ function pressEnterToSubmit(element) {
  */
 async function clickSubmitOrEnter(submitSelector, inputElement, timeout = 8000) {
   const start = Date.now();
+  const isClickable = (btn) => btn && !btn.disabled && btn.getAttribute("aria-disabled") !== "true";
+  const doClick = async (btn) => {
+    btn.scrollIntoView({ block: "center" });
+    await new Promise((r) => setTimeout(r, 100));
+    btn.click();
+    return true;
+  };
+
   while (Date.now() - start < timeout) {
     // セレクタをカンマ区切りで複数試行
     const selectors = submitSelector.split(",").map((s) => s.trim());
     for (const sel of selectors) {
       try {
         const btn = document.querySelector(sel);
-        if (btn && !btn.disabled && btn.getAttribute("aria-disabled") !== "true") {
-          btn.scrollIntoView({ block: "center" });
-          await new Promise((r) => setTimeout(r, 100));
-          btn.click();
+        if (isClickable(btn)) {
+          await doClick(btn);
           return true;
         }
       } catch { /* セレクタが不正な場合は無視 */ }
     }
+
+    // 入力欄近くの送信ボタンを探す（UI変更時のフォールバック）
+    if (inputElement) {
+      const form = inputElement.closest("form");
+      const container = inputElement.closest("[role='form'], [class*='composer'], [class*='input'], [class*='Composer']") || inputElement.parentElement;
+      const scope = form || container;
+      if (scope) {
+        const nearbyBtns = scope.querySelectorAll("button[type='submit'], button[aria-label*='Send'], button[aria-label*='送信'], [role='button'][aria-label*='Send']");
+        for (const b of nearbyBtns) {
+          if (isClickable(b)) {
+            await doClick(b);
+            return true;
+          }
+        }
+      }
+    }
+
     await new Promise((r) => setTimeout(r, 300));
   }
 

--- a/ai-prompt-broadcaster/storage.js
+++ b/ai-prompt-broadcaster/storage.js
@@ -23,7 +23,7 @@
         name: "Claude",
         url: "https://claude.ai/",
         inputSelector: "div[data-testid='chat-input'], div.tiptap.ProseMirror[contenteditable='true'], .ProseMirror[contenteditable='true']",
-        submitButtonSelector: "button[class*='Button_claude'], div.shrink-0 button[aria-label]",
+        submitButtonSelector: "button[class*='Button_claude'], div.shrink-0 button[aria-label], button[aria-label*='Send'], button[aria-label*='送信'], [data-testid='send-button'], button[data-testid*='send'], form button[type='submit'], button[type='submit']",
         answerContainerSelector: "[data-testid='conversation-thread'], main",
         copyButtonSelector: "[data-testid='action-bar-copy'], button[aria-label='Copy'], [aria-label*='Copy'], [aria-label*='コピー']",
         doneCheckSelector: ""
@@ -32,7 +32,7 @@
         name: "Gemini",
         url: "https://gemini.google.com/app",
         inputSelector: "rich-textarea div[contenteditable='true'], div[contenteditable='true'], textarea",
-        submitButtonSelector: "button.send-button, button[aria-label='Send message'], button[type='submit']",
+        submitButtonSelector: "button.send-button, button[aria-label='Send message'], button[aria-label*='Send'], button[aria-label*='送信'], button[mat-icon-button], button[mat-icon-button][aria-label], [aria-label='Send message'], button[type='submit'], [data-testid*='send']",
         answerContainerSelector: "main",
         copyButtonSelector: "button[aria-label='Copy'], [aria-label*='Copy'], [aria-label*='コピー'], [data-testid*='copy']",
         doneCheckSelector: ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Claude と Gemini の送信ボタンの位置が変わったことによる送信失敗を修正しました。

## 変更内容

### 1. Claude の送信ボタンセレクタ拡張 (`content-claude.js`, `storage.js`)
- `button[aria-label*='Send']` - aria-label の部分一致
- `button[aria-label*='送信']` - 日本語ロケール対応
- `[data-testid='send-button']`, `button[data-testid*='send']` - data-testid 対応
- `form button[type='submit']`, `button[type='submit']` - フォーム送信ボタン

### 2. Gemini の送信ボタンセレクタ拡張 (`content-gemini.js`, `storage.js`)
- `button[aria-label*='Send']`, `button[aria-label*='送信']` - 部分一致
- `button[mat-icon-button][aria-label]` - Angular Material のアイコンボタン
- `[aria-label='Send message']` - ボタン以外の要素も対象
- `[data-testid*='send']` - data-testid 対応

### 3. 入力欄近くの送信ボタン検索フォールバック (`content-utils.js`)
- セレクタで見つからない場合、入力欄の親要素（form、composer など）内の送信ボタンを検索
- UI 構造変更時にも送信ボタンを発見しやすくする

## テスト
- ビルド不要のため、Chrome 拡張のリロードで動作確認可能
- E2E テストは Playwright ブラウザのインストールが必要（環境依存）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a09385cd-9a9f-450a-9950-07f3d22e844d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a09385cd-9a9f-450a-9950-07f3d22e844d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

