### PR TITLE
Claudeの回答取得速度を改善

### DIFF
--- a/ai-prompt-broadcaster/content-base.js
+++ b/ai-prompt-broadcaster/content-base.js
@@ -22,7 +22,8 @@
       const submitSelector = config.submitButtonSelector;
       const answerSelector = config.answerContainerSelector;
       const copySelector = config.copyButtonSelector;
-      const doneSelector = config.doneCheckSelector || "";
+      // ストレージに空が保存されていても defaultConfig の doneCheckSelector をフォールバック
+      const doneSelector = (config.doneCheckSelector || defaultConfig.doneCheckSelector || "").trim() || "";
       const submitMethod = config.submitMethod || "clickSubmitOrEnter";
       const useInputSuccessFallback = config.inputSuccessFallback === "chatgpt";
 

--- a/ai-prompt-broadcaster/content-utils.js
+++ b/ai-prompt-broadcaster/content-utils.js
@@ -111,7 +111,7 @@ async function waitForResponseComplete(answerContainerSelector, doneCheckSelecto
     while (Date.now() - start < maxWaitMs) {
       const indicator = document.querySelector(doneCheckSelector);
       if (!indicator) break; // 停止ボタン等が消えた = 応答完了
-      await new Promise((r) => setTimeout(r, 1000));
+      await new Promise((r) => setTimeout(r, 300)); // 300ms間隔でポーリング（応答完了の検出を高速化）
     }
   }
 

--- a/ai-prompt-broadcaster/storage.js
+++ b/ai-prompt-broadcaster/storage.js
@@ -26,7 +26,7 @@
         submitButtonSelector: "button[class*='Button_claude'], div.shrink-0 button[aria-label]",
         answerContainerSelector: "[data-testid='conversation-thread'], main",
         copyButtonSelector: "[data-testid='action-bar-copy'], button[aria-label='Copy'], [aria-label*='Copy'], [aria-label*='コピー']",
-        doneCheckSelector: ""
+        doneCheckSelector: "[data-testid='stop-button'], button[aria-label='Stop']"
       },
       gemini: {
         name: "Gemini",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Claudeの回答取得が他サービスより遅い問題を修正しました。

## 原因
1. **doneCheckSelector が空**: `storage.js` のデフォルトで Claude の `doneCheckSelector` が空になっており、応答中の停止ボタンで完了を検出できず、DOM の安定待ち（最大15秒＋1.5秒）に依存していた
2. **ポーリング間隔が長い**: 停止ボタン検出のポーリングが 1000ms 間隔で、応答完了の検出が遅れていた

## 変更内容

### storage.js
- Claude の `doneCheckSelector` に `[data-testid='stop-button'], button[aria-label='Stop']` をデフォルト設定
- 停止ボタンが消えた時点で応答完了を検出できるように

### content-base.js
- ストレージに空の `doneCheckSelector` が保存されていても、各 content script の `defaultConfig` の値をフォールバックとして使用するよう修正
- 既存ユーザーでも content-claude.js の正しいセレクタが適用される

### content-utils.js
- Phase 2（停止ボタン消滅待ち）のポーリング間隔を 1000ms → 300ms に短縮
- 応答完了の検出を高速化（全AIサービスに適用）

## 期待される効果
- Claude の回答取得が、停止ボタン消滅後おおよそ 300ms〜1.5 秒程度で完了するようになる
- 従来の DOM 安定待ちによる最大 15 秒以上の遅延を回避
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2062ecf0-a681-4e25-94c5-0e6e94e5c5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2062ecf0-a681-4e25-94c5-0e6e94e5c5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

