### PR TITLE
feat: 既存の会話に続けて質問を送信する機能を追加

### DIFF
--- a/ai-prompt-broadcaster/background.js
+++ b/ai-prompt-broadcaster/background.js
@@ -6,6 +6,7 @@ const FAILED_ITEMS_KEY = STORAGE_KEYS.FAILED_ITEMS;
 const CURRENT_TASK_KEY = STORAGE_KEYS.CURRENT_TASK;
 const AI_TAB_IDS_KEY = STORAGE_KEYS.AI_TAB_IDS;
 const FOLDER_SEQ_KEY = STORAGE_KEYS.FOLDER_SEQ;
+const LAST_SAVED_FOLDER_KEY = STORAGE_KEYS.LAST_SAVED_FOLDER;
 const FOCUS_DELAY_MS = TIMEOUT_MS.FOCUS_DELAY;
 
 const NOTIFICATION_ICON_URL = chrome.runtime.getURL("icon128.png");
@@ -116,6 +117,55 @@ async function saveToObsidian(question, results, settings) {
       return { ok: false, error: res.error, payload: { question, results, basePath } };
     }
   }
+  await new Promise((resolve) =>
+    chrome.storage.local.set({ [LAST_SAVED_FOLDER_KEY]: basePath }, resolve)
+  );
+  return { ok: true };
+}
+
+/** 続きの質問を既存フォルダに追記する */
+async function appendToObsidian(basePath, question, results, settings) {
+  const { baseUrl, token } = settings.obsidian || {};
+
+  if (!baseUrl) {
+    return { ok: false, error: "ObsidianのベースURLが設定されていません" };
+  }
+
+  const questionAppend = `---\n\n## 続きの質問\n\n${question}\n\n`;
+  const resQuestion = await self.ObsidianClient.appendToNote(
+    baseUrl,
+    token,
+    `${basePath}/question.md`,
+    questionAppend
+  );
+  if (!resQuestion.ok) {
+    return { ok: false, error: resQuestion.error };
+  }
+
+  for (const r of results) {
+    const appendContent = `---\n\n### 続きの質問\n\n${question}\n\n### 回答\n\n${r.markdown || "(取得できませんでした)"}\n\n`;
+    const res = await self.ObsidianClient.appendToNote(
+      baseUrl,
+      token,
+      `${basePath}/${r.name}.md`,
+      appendContent
+    );
+    if (!res.ok) {
+      return { ok: false, error: res.error };
+    }
+  }
+
+  const summaryAppend = `---\n\n## 続きの質問\n\n${question}\n\n${buildSummary(results)}`;
+  const resSummary = await self.ObsidianClient.appendToNote(
+    baseUrl,
+    token,
+    `${basePath}/Summary.md`,
+    summaryAppend
+  );
+  if (!resSummary.ok) {
+    return { ok: false, error: resSummary.error };
+  }
+
   return { ok: true };
 }
 
@@ -445,16 +495,36 @@ async function runTask(task) {
   let saveResult = { ok: false };
 
   if (hasAnyMarkdown) {
-    saveResult = await saveToObsidian(task.prompt, results, settings);
+    if (task.isFollowUp) {
+      const basePath = task.basePath || (await new Promise((resolve) =>
+        chrome.storage.local.get(LAST_SAVED_FOLDER_KEY, (x) => resolve(x[LAST_SAVED_FOLDER_KEY]))
+      );
+      if (!basePath) {
+        saveResult = { ok: false, error: "続きの質問に対応する保存先フォルダが見つかりません。先に新規質問を送信・保存してください。" };
+      } else {
+        saveResult = await appendToObsidian(basePath, task.prompt, results, settings);
+      }
+    } else {
+      saveResult = await saveToObsidian(task.prompt, results, settings);
+    }
   }
 
   if (!saveResult.ok) {
     if (hasAnyMarkdown) {
-      await appendFailedItemToLocal({
-        question: task.prompt,
-        results,
-        error: saveResult.error
-      });
+      const failedPayload = { question: task.prompt, results, error: saveResult.error };
+      if (task.isFollowUp && task.basePath) {
+        failedPayload.isFollowUp = true;
+        failedPayload.basePath = task.basePath;
+      } else if (task.isFollowUp) {
+        const lastFolder = await new Promise((resolve) =>
+          chrome.storage.local.get(LAST_SAVED_FOLDER_KEY, (x) => resolve(x[LAST_SAVED_FOLDER_KEY]))
+        );
+        if (lastFolder) {
+          failedPayload.isFollowUp = true;
+          failedPayload.basePath = lastFolder;
+        }
+      }
+      await appendFailedItemToLocal(failedPayload);
       showNotification("MirrorChat: 一部失敗", `Obsidian保存失敗。失敗: ${failed.join(", ")}。再送可能です。`);
     } else {
       showNotification("MirrorChat: 取得失敗", `全てのAIから回答を取得できませんでした。Obsidianには保存しませんでした。`);
@@ -603,9 +673,10 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         await loadAiTabIds();
         const prompt = msg.prompt;
         // 現在の質問をローカルストレージに保持（ポップアップ再表示時などに利用）
+        const isFollowUp = !!msg.isFollowUp;
         await new Promise((resolve) =>
           chrome.storage.local.set(
-            { [CURRENT_TASK_KEY]: { prompt, createdAt: Date.now() } },
+            { [CURRENT_TASK_KEY]: { prompt, createdAt: Date.now(), isFollowUp } },
             resolve
           )
         );
@@ -647,7 +718,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         return;
       }
       await loadAiTabIds();
-      queue.push({ prompt: current.prompt });
+      queue.push({ prompt: current.prompt, isFollowUp: !!current.isFollowUp });
       if (!processing) processNext();
       sendResponse({ ok: true });
     });
@@ -656,7 +727,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     chrome.storage.local.get(FAILED_ITEMS_KEY, (x) => {
       const items = x[FAILED_ITEMS_KEY] || [];
       chrome.storage.local.set({ [FAILED_ITEMS_KEY]: [] });
-      items.forEach((it) => queue.push({ prompt: it.question, retryPayload: it }));
+      items.forEach((it) => {
+        const task = { prompt: it.question, retryPayload: it };
+        if (it.isFollowUp) task.isFollowUp = true;
+        if (it.basePath) task.basePath = it.basePath;
+        queue.push(task);
+      });
       if (!processing && queue.length > 0) processNext();
       sendResponse({ ok: true });
     });

--- a/ai-prompt-broadcaster/constants.js
+++ b/ai-prompt-broadcaster/constants.js
@@ -10,7 +10,8 @@
     CURRENT_TASK: "mirrorchatCurrentTask",
     SETTINGS: "mirrorchatSettings",
     AI_TAB_IDS: "mirrorchatAiTabIds",
-    FOLDER_SEQ: "mirrorchatFolderSeq"
+    FOLDER_SEQ: "mirrorchatFolderSeq",
+    LAST_SAVED_FOLDER: "mirrorchatLastSavedFolder"
   };
 
   const TIMEOUT_MS = {

--- a/ai-prompt-broadcaster/obsidianClient.js
+++ b/ai-prompt-broadcaster/obsidianClient.js
@@ -1,19 +1,25 @@
 /**
  * Obsidian Local REST API クライアント
- * ノート作成・URL組み立て・認証・リトライを1か所で扱う
+ * ノート作成・読み取り・追記・URL組み立て・認証・リトライを1か所で扱う
  */
 (function () {
   const MAX_RETRIES = 2;
   const RETRY_DELAY_BASE_MS = 500;
 
+  function buildHeaders(token, contentType) {
+    const headers = {};
+    if (contentType) headers["Content-Type"] = contentType;
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    return headers;
+  }
+
+  function buildUrl(baseUrl, path) {
+    return `${baseUrl.replace(/\/$/, "")}/vault/${path.replace(/^\//, "")}`;
+  }
+
   async function createNote(baseUrl, token, path, content) {
-    const url = `${baseUrl.replace(/\/$/, "")}/vault/${path.replace(/^\//, "")}`;
-    const headers = {
-      "Content-Type": "text/markdown"
-    };
-    if (token) {
-      headers["Authorization"] = `Bearer ${token}`;
-    }
+    const url = buildUrl(baseUrl, path);
+    const headers = buildHeaders(token, "text/markdown");
 
     let lastError;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -37,7 +43,46 @@
     return { ok: false, error: lastError?.message || String(lastError) };
   }
 
+  /**
+   * 既存ノートの内容を取得する（続きの質問用）
+   */
+  async function getNote(baseUrl, token, path) {
+    const url = buildUrl(baseUrl, path);
+    const headers = buildHeaders(token);
+
+    let lastError;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const res = await fetch(url, {
+          method: "GET",
+          headers
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+        }
+        const text = await res.text();
+        return { ok: true, content: text };
+      } catch (err) {
+        lastError = err;
+        if (attempt < MAX_RETRIES) {
+          await new Promise((r) => setTimeout(r, RETRY_DELAY_BASE_MS * (attempt + 1)));
+        }
+      }
+    }
+    return { ok: false, error: lastError?.message || String(lastError) };
+  }
+
+  /**
+   * 既存ノートに追記する（続きの質問用）。ファイルが存在しない場合は新規作成する。
+   */
+  async function appendToNote(baseUrl, token, path, appendContent) {
+    const getRes = await getNote(baseUrl, token, path);
+    const existing = getRes.ok ? getRes.content : "";
+    const newContent = existing ? `${existing}\n\n${appendContent}` : appendContent;
+    return createNote(baseUrl, token, path, newContent);
+  }
+
   if (typeof self !== "undefined") {
-    self.ObsidianClient = { createNote };
+    self.ObsidianClient = { createNote, getNote, appendToNote };
   }
 })();

--- a/ai-prompt-broadcaster/popup.css
+++ b/ai-prompt-broadcaster/popup.css
@@ -62,6 +62,22 @@ label {
   margin-bottom: 8px;
 }
 
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.checkbox-row input[type="checkbox"] {
+  margin: 0;
+}
+
+.checkbox-row span {
+  font-size: 12px;
+  color: #444;
+}
+
 textarea {
   width: 100%;
   box-sizing: border-box;

--- a/ai-prompt-broadcaster/popup.html
+++ b/ai-prompt-broadcaster/popup.html
@@ -38,6 +38,10 @@
         質問
         <textarea id="prompt-input" rows="4" placeholder="ここに質問を入力..."></textarea>
       </label>
+      <label class="checkbox-row">
+        <input type="checkbox" id="follow-up-checkbox" />
+        <span>既存の会話に続けて送信</span>
+      </label>
       <div class="actions">
         <button id="send-button" disabled>送信</button>
         <button id="collect-button" disabled>回答を取得</button>

--- a/ai-prompt-broadcaster/popup.js
+++ b/ai-prompt-broadcaster/popup.js
@@ -19,6 +19,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   const promptInput = document.getElementById("prompt-input");
+  const followUpCheckbox = document.getElementById("follow-up-checkbox");
   const sendButton = document.getElementById("send-button");
   const collectButton = document.getElementById("collect-button");
   const openTabsButton = document.getElementById("open-tabs-button");
@@ -98,14 +99,19 @@ document.addEventListener("DOMContentLoaded", async () => {
       status.textContent = "質問を入力してください。";
       return;
     }
+    const isFollowUp = followUpCheckbox.checked;
+    if (isFollowUp) {
+      status.textContent = "続きの質問を送信中...各AIの既存会話に追加されます。回答生成完了後に「回答を取得」を押してください。";
+    } else {
+      status.textContent = "送信中...各AIに質問を送っています。回答生成完了後に「回答を取得」を押してください。";
+    }
     // 一度送信した質問が処理中の間は、新しい送信は行わない
     sendButton.disabled = true;
     collectButton.disabled = false;
-    status.textContent = "送信中...各AIに質問を送っています。回答生成完了後に「回答を取得」を押してください。";
 
     AI_KEYS.forEach((key) => setIndicator(key, "sending"));
 
-    chrome.runtime.sendMessage({ type: "MIRRORCHAT_SEND", prompt: text }, (resp) => {
+    chrome.runtime.sendMessage({ type: "MIRRORCHAT_SEND", prompt: text, isFollowUp }, (resp) => {
       if (chrome.runtime.lastError) {
         status.textContent = "送信に失敗しました: " + chrome.runtime.lastError.message;
         sendButton.disabled = false;
@@ -193,6 +199,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const current = data?.[currentTaskKey];
     if (current?.prompt) {
       promptInput.value = current.prompt;
+      followUpCheckbox.checked = !!current.isFollowUp;
       status.textContent = "前回の質問の回答が未取得です。「回答を取得」を押してObsidianに保存してください。";
     }
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
既に質問済みの会話に続けて、追加の質問を送信できる機能を追加しました。

## 変更内容

### ユーザー体験
- ポップアップに「既存の会話に続けて送信」チェックボックスを追加
- チェックを入れて送信すると、直前に保存したObsidianフォルダに続きのQ&Aが追記される
- 各AIサイトのタブは同じ会話を開いたまま維持し、続きの質問を送信する

### 技術的な変更
- **constants.js**: `LAST_SAVED_FOLDER` ストレージキーを追加
- **obsidianClient.js**: `getNote`（ファイル読み取り）と `appendToNote`（追記）メソッドを追加
- **background.js**: 
  - 保存成功時にフォルダパスを `LAST_SAVED_FOLDER` に保存
  - `appendToObsidian` 関数で既存フォルダへの追記を実装
  - 続きの質問の保存失敗時も再送信でリトライ可能
- **popup.html/js/css**: チェックボックスUIと送信時の `isFollowUp` フラグの受け渡し

### Obsidian への保存形式
続きの質問は以下の形式で既存ファイルに追記されます：

- **question.md**: `---` + `## 続きの質問` + 新しい質問
- **各AIの回答ファイル**: `---` + `### 続きの質問` + 質問 + `### 回答` + 回答
- **Summary.md**: 同様の形式で追記

## 使い方
1. 通常通り「サイトを開く」→ 質問を入力 → 「送信」→ 「回答を取得」で最初の質問を保存
2. 続きの質問を入力し、「既存の会話に続けて送信」にチェックを入れる
3. 「送信」→ 各AIの回答が出揃ったら「回答を取得」
4. 直前に保存したフォルダに続きのQ&Aが追記される

## 注意事項
- 続きの質問を使うには、先に新規質問を1回以上送信・保存しておく必要があります
- 保存先は「直前に保存したフォルダ」のみ対応（過去の特定フォルダを選択する機能は未実装）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dc31e83-e4a3-4ad6-ace4-bca12a5ce950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dc31e83-e4a3-4ad6-ace4-bca12a5ce950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

