### PR TITLE
E2Eをheadlessデフォルトに変更

### DIFF
--- a/docs/E2E_LOGIN_PROFILE.md
+++ b/docs/E2E_LOGIN_PROFILE.md
@@ -74,6 +74,9 @@ pnpm run test:with-profile
 1. `chrome-profile.zip` を `e2e/.chrome-profile/` に展開
 2. `MIRRORCHAT_USER_DATA_DIR` を設定してテストを実行
 
+既定では headless 実行のため、ローカル作業中でもブラウザウィンドウは表示されません。
+表示しながら確認したい場合だけ `pnpm run test:with-profile:headed` を使ってください。
+
 ---
 
 ## トラブルシューティング
@@ -135,7 +138,10 @@ cd /workspace/e2e
 # zip を展開（初回のみ）
 unzip -o chrome-profile.zip -d .chrome-profile/
 
-# テスト実行
+# テスト実行（headless）
+MIRRORCHAT_USER_DATA_DIR=/workspace/e2e/.chrome-profile pnpm test
+
+# ブラウザを表示して実行したい場合
 MIRRORCHAT_USER_DATA_DIR=/workspace/e2e/.chrome-profile pnpm test:headed
 ```
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,7 +13,7 @@ pnpm exec playwright install chromium
 ## 実行方法
 
 ```bash
-# ヘッドレスモード（CI向け）
+# デフォルトは headless 実行（ブラウザウィンドウは表示しない）
 pnpm test
 
 # ブラウザを表示して実行
@@ -30,7 +30,10 @@ pnpm test:ui
 ### ローカルで実行する場合
 
 ```bash
-# Linux の Chrome User Data ディレクトリ例
+# Linux の Chrome User Data ディレクトリ例（headless 実行）
+MIRRORCHAT_USER_DATA_DIR=~/.config/google-chrome pnpm test
+
+# ブラウザを表示したい場合
 MIRRORCHAT_USER_DATA_DIR=~/.config/google-chrome pnpm test:headed
 ```
 
@@ -42,9 +45,14 @@ MIRRORCHAT_USER_DATA_DIR=~/.config/google-chrome pnpm test:headed
 
 ```bash
 cd e2e
-pnpm test:with-profile:headed
+pnpm test:with-profile
 ```
 
 詳細な手順は [docs/E2E_LOGIN_PROFILE.md](../docs/E2E_LOGIN_PROFILE.md) を参照してください。
 
 未ログインの場合は「サイトを開く」「ポップアップ表示」などの基本動作のみ検証されます。
+
+## 備考
+
+- `pnpm test` / `pnpm test:with-profile` は一時プロファイルを使うため、前回の拡張設定が次回実行へ残りません
+- `--headed` または `pnpm test:headed` / `pnpm test:with-profile:headed` を使うと、従来どおりブラウザを表示して確認できます

--- a/e2e/fixtures.js
+++ b/e2e/fixtures.js
@@ -5,6 +5,8 @@
  * @see https://playwright.dev/docs/chrome-extensions
  */
 const { test: base, chromium } = require("@playwright/test");
+const fs = require("fs/promises");
+const os = require("os");
 const path = require("path");
 
 const pathToExtension = path.join(__dirname, "..", "ai-prompt-broadcaster");
@@ -13,22 +15,48 @@ const pathToExtension = path.join(__dirname, "..", "ai-prompt-broadcaster");
  * ログイン済みのChromeプロファイルを使う場合、環境変数で指定する
  * 例: MIRRORCHAT_USER_DATA_DIR=/home/user/.config/google-chrome/Default
  */
-const userDataDir =
-  process.env.MIRRORCHAT_USER_DATA_DIR || path.join(__dirname, ".playwright-user-data");
+const userDataDir = process.env.MIRRORCHAT_USER_DATA_DIR || "";
+
+function shouldRunHeaded() {
+  return process.argv.includes("--headed") || process.argv.includes("--ui");
+}
+
+async function prepareUserDataDir() {
+  if (userDataDir) {
+    return {
+      dir: userDataDir,
+      cleanup: async () => {}
+    };
+  }
+
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mirrorchat-e2e-"));
+  return {
+    dir,
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  };
+}
 
 const test = base.extend({
   context: async ({}, use) => {
-    // Chrome拡張は headed モード必須。CI では xvfb で仮想ディスプレイを使用
-    const context = await chromium.launchPersistentContext(userDataDir, {
-      headless: false,
+    const { dir, cleanup } = await prepareUserDataDir();
+    const context = await chromium.launchPersistentContext(dir, {
+      channel: "chromium",
+      headless: !shouldRunHeaded(),
       args: [
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
       ],
       ignoreDefaultArgs: ["--disable-extensions"],
     });
-    await use(context);
-    await context.close();
+
+    try {
+      await use(context);
+    } finally {
+      await context.close();
+      await cleanup();
+    }
   },
 
   extensionId: async ({ context }, use) => {


### PR DESCRIPTION
## 概要
- E2E テストを headless デフォルトに変更
- 通常実行時は一時プロファイルを使うようにして、前回実行の状態が残りにくいよう改善
- ドキュメントの実行方法を実態に合わせて更新

## 変更内容
- `e2e/fixtures.js`
  - `pnpm test` の既定実行を headless 化
  - `--headed` / `--ui` のときだけ表示ありで起動
  - `MIRRORCHAT_USER_DATA_DIR` 未指定時は一時 user data dir を作成し、終了時に削除
- `e2e/README.md`
  - headless デフォルトと headed 明示実行の使い分けを追記
- `docs/E2E_LOGIN_PROFILE.md`
  - ログイン済みプロファイル利用時も headless が既定であることを追記

## 動作確認
- `cd e2e && pnpm test --grep "ポップアップが表示され、タイトルが正しい|AIモデル順を保存すると options と popup の順番に反映される"`
- `cd e2e && pnpm test`
  - 19件中18件成功
  - `OpenRouter digest 設定を保存・復元できる` の既存失敗は継続

## 補足
- 今回の目的は「ローカル作業中にブラウザウィンドウを出さずに E2E を流せるようにすること」
- full E2E の未解決 1件は今回の主目的外として別途対応
