### PR TITLE
AIモデル順をGemini先頭に変更し設定で並び替え可能にする

### DIFF
--- a/ai-prompt-broadcaster/aiOrderUtils.js
+++ b/ai-prompt-broadcaster/aiOrderUtils.js
@@ -1,0 +1,80 @@
+(function () {
+  const root = typeof self !== "undefined" ? self : window;
+  const constants = root.MirrorChatConstants || {};
+  const AI_KEYS = Array.isArray(constants.AI_KEYS)
+    ? constants.AI_KEYS
+    : ["chatgpt", "claude", "gemini", "grok"];
+  const AI_DEFAULT_ORDER = Array.isArray(constants.AI_DEFAULT_ORDER)
+    ? constants.AI_DEFAULT_ORDER
+    : ["gemini", "chatgpt", "claude", "grok"];
+
+  function normalizeAiOrder(rawOrder) {
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const ordered = [];
+
+    if (Array.isArray(rawOrder)) {
+      rawOrder.forEach((aiKey) => {
+        const key = String(aiKey || "").trim();
+        if (!key || !validKeys.has(key) || seen.has(key)) return;
+        seen.add(key);
+        ordered.push(key);
+      });
+    }
+
+    AI_DEFAULT_ORDER.forEach((aiKey) => {
+      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+
+    AI_KEYS.forEach((aiKey) => {
+      if (!seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+
+    return ordered;
+  }
+
+  function resolveEnabledAIs(rawEnabledAIs, aiOrder) {
+    if (typeof rawEnabledAIs === "undefined") {
+      return normalizeAiOrder(aiOrder);
+    }
+    if (!Array.isArray(rawEnabledAIs)) return [];
+
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const enabled = [];
+    rawEnabledAIs.forEach((aiKey) => {
+      const key = String(aiKey || "").trim();
+      if (!key || !validKeys.has(key) || seen.has(key)) return;
+      seen.add(key);
+      enabled.push(key);
+    });
+    return enabled;
+  }
+
+  function normalizeEnabledAiMap(enabledAIs, aiOrder) {
+    const ordered = normalizeAiOrder(aiOrder);
+    const next = {};
+    ordered.forEach((aiKey) => {
+      next[aiKey] = typeof enabledAIs?.[aiKey] === "boolean" ? enabledAIs[aiKey] : true;
+    });
+    return next;
+  }
+
+  function getDefaultEnabledAiMap(aiOrder) {
+    const ordered = normalizeAiOrder(aiOrder);
+    return Object.fromEntries(ordered.map((aiKey) => [aiKey, true]));
+  }
+
+  root.MirrorChatAIOrderUtils = {
+    normalizeAiOrder,
+    resolveEnabledAIs,
+    normalizeEnabledAiMap,
+    getDefaultEnabledAiMap
+  };
+})();

--- a/ai-prompt-broadcaster/background.js
+++ b/ai-prompt-broadcaster/background.js
@@ -12,7 +12,7 @@ importScripts(
   "aiCommunication.js"
 );
 
-const { AI_KEYS, STORAGE_KEYS, MESSAGE_TYPES } = self.MirrorChatConstants;
+const { AI_KEYS, AI_DEFAULT_ORDER, STORAGE_KEYS, MESSAGE_TYPES } = self.MirrorChatConstants;
 const CURRENT_TASK_KEY = STORAGE_KEYS.CURRENT_TASK;
 const LAST_SAVED_FOLDER_KEY = STORAGE_KEYS.LAST_SAVED_FOLDER;
 const LAST_NOTE_SNAPSHOT_KEY = STORAGE_KEYS.LAST_NOTE_SNAPSHOT;
@@ -155,17 +155,54 @@ async function runDigestFollowUp({ question, results, settings, notePath }) {
   sendDigestStatus(`digest を反映しました。使用モデル: ${digestResult.modelId}`, { tone: "success" });
 }
 
-function resolveEnabledAIs(rawEnabledAIs) {
-  if (typeof rawEnabledAIs === "undefined") return [...AI_KEYS];
+function normalizeAiOrder(rawOrder) {
+  const validKeys = new Set(AI_KEYS);
+  const seen = new Set();
+  const ordered = [];
+  if (Array.isArray(rawOrder)) {
+    rawOrder.forEach((aiKey) => {
+      const key = String(aiKey || "").trim();
+      if (!key || !validKeys.has(key) || seen.has(key)) return;
+      seen.add(key);
+      ordered.push(key);
+    });
+  }
+  (AI_DEFAULT_ORDER || []).forEach((aiKey) => {
+    if (validKeys.has(aiKey) && !seen.has(aiKey)) {
+      seen.add(aiKey);
+      ordered.push(aiKey);
+    }
+  });
+  AI_KEYS.forEach((aiKey) => {
+    if (!seen.has(aiKey)) {
+      seen.add(aiKey);
+      ordered.push(aiKey);
+    }
+  });
+  return ordered;
+}
+
+function resolveEnabledAIs(rawEnabledAIs, aiOrder) {
+  const validKeys = new Set(AI_KEYS);
+  const normalizedOrder = normalizeAiOrder(aiOrder);
+  if (typeof rawEnabledAIs === "undefined") return normalizedOrder;
   if (!Array.isArray(rawEnabledAIs)) return [];
-  return AI_KEYS.filter((key) => rawEnabledAIs.includes(key));
+  const seen = new Set();
+  const enabled = [];
+  rawEnabledAIs.forEach((aiKey) => {
+    const key = String(aiKey || "").trim();
+    if (!key || !validKeys.has(key) || seen.has(key)) return;
+    seen.add(key);
+    enabled.push(key);
+  });
+  return enabled;
 }
 
 tabManager.setStatusNotifier(aiCommunication.notifyAIStatus);
 
 async function runTask(task) {
   const settings = await self.MirrorChatStorage.getSettings();
-  const enabledAIs = resolveEnabledAIs(task.enabledAIs);
+  const enabledAIs = resolveEnabledAIs(task.enabledAIs, settings.aiOrder);
   let results;
 
   if (task.retryPayload?.results) {
@@ -395,7 +432,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         try {
           await tabManager.loadAiTabIds();
           const prompt = msg.prompt;
-          const enabledAIs = resolveEnabledAIs(msg.enabledAIs);
+          const settings = await self.MirrorChatStorage.getSettings();
+          const enabledAIs = resolveEnabledAIs(msg.enabledAIs, settings.aiOrder);
           if (enabledAIs.length === 0) {
             sendResponse({ ok: false, error: "使用する AI を1つ以上選択してください。" });
             return;
@@ -409,7 +447,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
             )
           );
 
-          const settings = await self.MirrorChatStorage.getSettings();
           const sendPromises = enabledAIs.map((aiKey) => {
             if (!tabManager.getTabId(aiKey)) {
               const cfg = settings.aiConfigs?.[aiKey];
@@ -444,11 +481,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           sendResponse({ ok: false, error: "取得対象の質問が見つかりませんでした" });
           return;
         }
+        const settings = await self.MirrorChatStorage.getSettings();
         await tabManager.loadAiTabIds();
         taskQueue.enqueue({
           prompt: current.prompt,
           isFollowUp: !!current.isFollowUp,
-          enabledAIs: resolveEnabledAIs(current.enabledAIs)
+          enabledAIs: resolveEnabledAIs(current.enabledAIs, settings.aiOrder)
         });
         if (!taskQueue.isProcessing()) processNext();
         sendResponse({ ok: true });

--- a/ai-prompt-broadcaster/background.js
+++ b/ai-prompt-broadcaster/background.js
@@ -1,5 +1,6 @@
 importScripts(
   "constants.js",
+  "aiOrderUtils.js",
   "storage.js",
   "obsidianClient.js",
   "openRouterFreeModels.js",
@@ -12,10 +13,11 @@ importScripts(
   "aiCommunication.js"
 );
 
-const { AI_KEYS, AI_DEFAULT_ORDER, STORAGE_KEYS, MESSAGE_TYPES } = self.MirrorChatConstants;
+const { STORAGE_KEYS, MESSAGE_TYPES } = self.MirrorChatConstants;
 const CURRENT_TASK_KEY = STORAGE_KEYS.CURRENT_TASK;
 const LAST_SAVED_FOLDER_KEY = STORAGE_KEYS.LAST_SAVED_FOLDER;
 const LAST_NOTE_SNAPSHOT_KEY = STORAGE_KEYS.LAST_NOTE_SNAPSHOT;
+const aiOrderUtils = self.MirrorChatAIOrderUtils;
 
 const NOTIFICATION_ICON_URL = chrome.runtime.getURL("icon128.png");
 
@@ -155,47 +157,8 @@ async function runDigestFollowUp({ question, results, settings, notePath }) {
   sendDigestStatus(`digest を反映しました。使用モデル: ${digestResult.modelId}`, { tone: "success" });
 }
 
-function normalizeAiOrder(rawOrder) {
-  const validKeys = new Set(AI_KEYS);
-  const seen = new Set();
-  const ordered = [];
-  if (Array.isArray(rawOrder)) {
-    rawOrder.forEach((aiKey) => {
-      const key = String(aiKey || "").trim();
-      if (!key || !validKeys.has(key) || seen.has(key)) return;
-      seen.add(key);
-      ordered.push(key);
-    });
-  }
-  (AI_DEFAULT_ORDER || []).forEach((aiKey) => {
-    if (validKeys.has(aiKey) && !seen.has(aiKey)) {
-      seen.add(aiKey);
-      ordered.push(aiKey);
-    }
-  });
-  AI_KEYS.forEach((aiKey) => {
-    if (!seen.has(aiKey)) {
-      seen.add(aiKey);
-      ordered.push(aiKey);
-    }
-  });
-  return ordered;
-}
-
 function resolveEnabledAIs(rawEnabledAIs, aiOrder) {
-  const validKeys = new Set(AI_KEYS);
-  const normalizedOrder = normalizeAiOrder(aiOrder);
-  if (typeof rawEnabledAIs === "undefined") return normalizedOrder;
-  if (!Array.isArray(rawEnabledAIs)) return [];
-  const seen = new Set();
-  const enabled = [];
-  rawEnabledAIs.forEach((aiKey) => {
-    const key = String(aiKey || "").trim();
-    if (!key || !validKeys.has(key) || seen.has(key)) return;
-    seen.add(key);
-    enabled.push(key);
-  });
-  return enabled;
+  return aiOrderUtils.resolveEnabledAIs(rawEnabledAIs, aiOrder);
 }
 
 tabManager.setStatusNotifier(aiCommunication.notifyAIStatus);

--- a/ai-prompt-broadcaster/constants.js
+++ b/ai-prompt-broadcaster/constants.js
@@ -4,6 +4,7 @@
  */
 (function () {
   const AI_KEYS = ["chatgpt", "claude", "gemini", "grok"];
+  const AI_DEFAULT_ORDER = ["gemini", "chatgpt", "claude", "grok"];
 
   const STORAGE_KEYS = {
     FAILED_ITEMS: "mirrorchatFailedItems",
@@ -148,6 +149,7 @@
   const target = typeof window !== "undefined" ? window : self;
   target.MirrorChatConstants = {
     AI_KEYS,
+    AI_DEFAULT_ORDER,
     STORAGE_KEYS,
     MESSAGE_TYPES,
     TIMEOUT_MS,

--- a/ai-prompt-broadcaster/options.css
+++ b/ai-prompt-broadcaster/options.css
@@ -125,3 +125,33 @@ button {
   line-height: 1.5;
 }
 
+.ai-order-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ai-order-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 8px;
+  margin-bottom: 8px;
+}
+
+.ai-order-name {
+  font-weight: 600;
+}
+
+.ai-order-controls {
+  display: flex;
+  gap: 6px;
+}
+
+.ai-order-button {
+  min-width: 36px;
+  padding: 4px 8px;
+}
+

--- a/ai-prompt-broadcaster/options.html
+++ b/ai-prompt-broadcaster/options.html
@@ -62,8 +62,14 @@
       </section>
 
       <section>
-        <h2>各AIサイトのDOMセレクタ</h2>
+        <h2>AIモデル順</h2>
+        <p>ここで設定した順番は、ポップアップ表示順・タブを開く順・送信対象順・回答取得順に反映されます。</p>
+        <ul id="ai-order-list" class="ai-order-list"></ul>
+      </section>
 
+      <section id="ai-configs-section">
+        <h2>各AIサイトのDOMセレクタ</h2>
+        <div id="ai-config-list">
         <div class="ai-config" data-ai="chatgpt">
           <h3>ChatGPT</h3>
           <label>
@@ -214,6 +220,7 @@
               <input class="input-success-fallback-selector" type="text" placeholder="通常は空欄" />
             </label>
           </details>
+        </div>
         </div>
       </section>
 

--- a/ai-prompt-broadcaster/options.html
+++ b/ai-prompt-broadcaster/options.html
@@ -237,6 +237,7 @@
     </main>
 
     <script src="constants.js"></script>
+  <script src="aiOrderUtils.js"></script>
     <script src="storage.js"></script>
     <script src="openRouterFreeModels.js"></script>
     <script src="openRouterClient.js"></script>

--- a/ai-prompt-broadcaster/options.js
+++ b/ai-prompt-broadcaster/options.js
@@ -17,13 +17,114 @@ document.addEventListener("DOMContentLoaded", async () => {
   const openRouterTestLog = document.getElementById("openrouter-test-log");
   const saveButton = document.getElementById("save-button");
   const status = document.getElementById("status");
+  const aiOrderList = document.getElementById("ai-order-list");
+  const aiConfigList = document.getElementById("ai-config-list");
 
   const storage = window.MirrorChatStorage;
   const openRouterClient = window.MirrorChatOpenRouterClient;
   const openRouterFreeModels = window.MirrorChatOpenRouterFreeModels;
   const digestService = window.MirrorChatDigestService;
+  const constants = window.MirrorChatConstants || {};
+  const AI_KEYS = constants.AI_KEYS || ["chatgpt", "claude", "gemini", "grok"];
+  const AI_DEFAULT_ORDER = constants.AI_DEFAULT_ORDER || ["gemini", "chatgpt", "claude", "grok"];
+  const AI_CONFIG_DEFAULTS = constants.AI_CONFIG_DEFAULTS || {};
   const MESSAGE_TYPES = window.MirrorChatConstants?.MESSAGE_TYPES || {};
   const MSG_RETRY = MESSAGE_TYPES.RETRY || "MIRRORCHAT_RETRY";
+
+  let currentAiOrder = normalizeAiOrder(AI_DEFAULT_ORDER);
+
+  function normalizeAiOrder(rawOrder) {
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const ordered = [];
+    if (Array.isArray(rawOrder)) {
+      rawOrder.forEach((aiKey) => {
+        const key = String(aiKey || "").trim();
+        if (!key || !validKeys.has(key) || seen.has(key)) return;
+        seen.add(key);
+        ordered.push(key);
+      });
+    }
+    AI_DEFAULT_ORDER.forEach((aiKey) => {
+      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    AI_KEYS.forEach((aiKey) => {
+      if (!seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    return ordered;
+  }
+
+  function getAiDisplayName(aiKey) {
+    return AI_CONFIG_DEFAULTS?.[aiKey]?.name || aiKey;
+  }
+
+  function applyAiOrderToConfigSections(aiOrder) {
+    if (!aiConfigList) return;
+    normalizeAiOrder(aiOrder).forEach((aiKey) => {
+      const section = aiConfigList.querySelector(`.ai-config[data-ai="${aiKey}"]`);
+      if (section) aiConfigList.appendChild(section);
+    });
+  }
+
+  function moveAiOrder(aiKey, offset) {
+    const index = currentAiOrder.indexOf(aiKey);
+    if (index === -1) return;
+    const nextIndex = index + offset;
+    if (nextIndex < 0 || nextIndex >= currentAiOrder.length) return;
+    const updated = [...currentAiOrder];
+    const [item] = updated.splice(index, 1);
+    updated.splice(nextIndex, 0, item);
+    currentAiOrder = updated;
+    renderAiOrderList();
+    applyAiOrderToConfigSections(currentAiOrder);
+  }
+
+  function renderAiOrderList() {
+    if (!aiOrderList) return;
+    aiOrderList.innerHTML = "";
+    currentAiOrder.forEach((aiKey, index) => {
+      const item = document.createElement("li");
+      item.className = "ai-order-item";
+      item.dataset.ai = aiKey;
+
+      const name = document.createElement("span");
+      name.className = "ai-order-name";
+      name.textContent = getAiDisplayName(aiKey);
+
+      const controls = document.createElement("div");
+      controls.className = "ai-order-controls";
+
+      const upButton = document.createElement("button");
+      upButton.type = "button";
+      upButton.className = "ai-order-button";
+      upButton.dataset.action = "up";
+      upButton.dataset.ai = aiKey;
+      upButton.textContent = "↑";
+      upButton.disabled = index === 0;
+      upButton.setAttribute("aria-label", `${getAiDisplayName(aiKey)} を上へ移動`);
+
+      const downButton = document.createElement("button");
+      downButton.type = "button";
+      downButton.className = "ai-order-button";
+      downButton.dataset.action = "down";
+      downButton.dataset.ai = aiKey;
+      downButton.textContent = "↓";
+      downButton.disabled = index === currentAiOrder.length - 1;
+      downButton.setAttribute("aria-label", `${getAiDisplayName(aiKey)} を下へ移動`);
+
+      controls.appendChild(upButton);
+      controls.appendChild(downButton);
+      item.appendChild(name);
+      item.appendChild(controls);
+      aiOrderList.appendChild(item);
+    });
+  }
 
   function setOpenRouterTestStatus(text, tone = "info") {
     openRouterTestStatus.textContent = text;
@@ -269,6 +370,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   async function restore() {
     const settings = await storage.getSettings();
 
+    currentAiOrder = normalizeAiOrder(settings.aiOrder);
+    renderAiOrderList();
+    applyAiOrderToConfigSections(currentAiOrder);
+
     baseUrlInput.value = settings.obsidian.baseUrl || "";
     tokenInput.value = settings.obsidian.token || "";
     rootPathInput.value = settings.obsidian.rootPath || "";
@@ -306,6 +411,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   async function save() {
     const partial = {
+      aiOrder: [...currentAiOrder],
       obsidian: {
         baseUrl: baseUrlInput.value.trim(),
         token: tokenInput.value.trim(),
@@ -421,6 +527,20 @@ document.addEventListener("DOMContentLoaded", async () => {
         "error"
       );
     });
+  });
+
+  aiOrderList?.addEventListener("click", (event) => {
+    const button = event.target.closest("button[data-action][data-ai]");
+    if (!button) return;
+    const aiKey = button.getAttribute("data-ai") || "";
+    const action = button.getAttribute("data-action") || "";
+    if (action === "up") {
+      moveAiOrder(aiKey, -1);
+      return;
+    }
+    if (action === "down") {
+      moveAiOrder(aiKey, 1);
+    }
   });
 });
 

--- a/ai-prompt-broadcaster/options.js
+++ b/ai-prompt-broadcaster/options.js
@@ -25,40 +25,14 @@ document.addEventListener("DOMContentLoaded", async () => {
   const openRouterFreeModels = window.MirrorChatOpenRouterFreeModels;
   const digestService = window.MirrorChatDigestService;
   const constants = window.MirrorChatConstants || {};
-  const AI_KEYS = constants.AI_KEYS || ["chatgpt", "claude", "gemini", "grok"];
   const AI_DEFAULT_ORDER = constants.AI_DEFAULT_ORDER || ["gemini", "chatgpt", "claude", "grok"];
   const AI_CONFIG_DEFAULTS = constants.AI_CONFIG_DEFAULTS || {};
+  const aiOrderUtils = window.MirrorChatAIOrderUtils;
+  const normalizeAiOrder = aiOrderUtils.normalizeAiOrder;
   const MESSAGE_TYPES = window.MirrorChatConstants?.MESSAGE_TYPES || {};
   const MSG_RETRY = MESSAGE_TYPES.RETRY || "MIRRORCHAT_RETRY";
 
   let currentAiOrder = normalizeAiOrder(AI_DEFAULT_ORDER);
-
-  function normalizeAiOrder(rawOrder) {
-    const validKeys = new Set(AI_KEYS);
-    const seen = new Set();
-    const ordered = [];
-    if (Array.isArray(rawOrder)) {
-      rawOrder.forEach((aiKey) => {
-        const key = String(aiKey || "").trim();
-        if (!key || !validKeys.has(key) || seen.has(key)) return;
-        seen.add(key);
-        ordered.push(key);
-      });
-    }
-    AI_DEFAULT_ORDER.forEach((aiKey) => {
-      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    AI_KEYS.forEach((aiKey) => {
-      if (!seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    return ordered;
-  }
 
   function getAiDisplayName(aiKey) {
     return AI_CONFIG_DEFAULTS?.[aiKey]?.name || aiKey;

--- a/ai-prompt-broadcaster/popup.html
+++ b/ai-prompt-broadcaster/popup.html
@@ -71,6 +71,7 @@
       </section>
     </main>
     <script src="constants.js"></script>
+    <script src="aiOrderUtils.js"></script>
     <script src="storage.js"></script>
     <script src="openRouterFreeModels.js"></script>
     <script src="popup.js"></script>

--- a/ai-prompt-broadcaster/popup.html
+++ b/ai-prompt-broadcaster/popup.html
@@ -11,6 +11,11 @@
       <p class="desc">AIサイトを先に開いてから、質問を送信します。</p>
 
       <section class="tab-status" id="tab-status">
+        <div class="tab-item" data-ai="gemini">
+          <input type="checkbox" class="ai-checkbox" data-ai="gemini" checked aria-label="Geminiを使用する" />
+          <span class="indicator" id="ind-gemini"></span>
+          <span class="tab-name">Gemini</span>
+        </div>
         <div class="tab-item" data-ai="chatgpt">
           <input type="checkbox" class="ai-checkbox" data-ai="chatgpt" checked aria-label="ChatGPTを使用する" />
           <span class="indicator" id="ind-chatgpt"></span>
@@ -20,11 +25,6 @@
           <input type="checkbox" class="ai-checkbox" data-ai="claude" checked aria-label="Claudeを使用する" />
           <span class="indicator" id="ind-claude"></span>
           <span class="tab-name">Claude</span>
-        </div>
-        <div class="tab-item" data-ai="gemini">
-          <input type="checkbox" class="ai-checkbox" data-ai="gemini" checked aria-label="Geminiを使用する" />
-          <span class="indicator" id="ind-gemini"></span>
-          <span class="tab-name">Gemini</span>
         </div>
         <div class="tab-item" data-ai="grok">
           <input type="checkbox" class="ai-checkbox" data-ai="grok" checked aria-label="Grokを使用する" />

--- a/ai-prompt-broadcaster/popup.js
+++ b/ai-prompt-broadcaster/popup.js
@@ -32,9 +32,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   const resaveButton = document.getElementById("resave-button");
   const regenerateDigestButton = document.getElementById("regenerate-digest-button");
   const digestModelSelect = document.getElementById("digest-model-select");
+  const tabStatus = document.getElementById("tab-status");
 
   const constants = window.MirrorChatConstants || {};
   const AI_KEYS = constants.AI_KEYS ?? ["chatgpt", "claude", "gemini", "grok"];
+  const AI_DEFAULT_ORDER = constants.AI_DEFAULT_ORDER ?? ["gemini", "chatgpt", "claude", "grok"];
   const MESSAGE_TYPES = constants.MESSAGE_TYPES || {};
   const currentTaskKey = constants.STORAGE_KEYS?.CURRENT_TASK ?? "mirrorchatCurrentTask";
   const failedItemsKey = constants.STORAGE_KEYS?.FAILED_ITEMS ?? "mirrorchatFailedItems";
@@ -57,17 +59,66 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const indicators = {};
   const aiCheckboxes = {};
+  const tabItems = {};
   AI_KEYS.forEach((key) => {
     indicators[key] = document.getElementById("ind-" + key);
     aiCheckboxes[key] = document.querySelector('.ai-checkbox[data-ai="' + key + '"]');
+    tabItems[key] = tabStatus?.querySelector('.tab-item[data-ai="' + key + '"]') || null;
   });
 
-  function getDefaultEnabledAIs() {
-    return Object.fromEntries(AI_KEYS.map((key) => [key, true]));
+  function normalizeAiOrder(rawOrder) {
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const ordered = [];
+    if (Array.isArray(rawOrder)) {
+      rawOrder.forEach((aiKey) => {
+        const key = String(aiKey || "").trim();
+        if (!key || !validKeys.has(key) || seen.has(key)) return;
+        seen.add(key);
+        ordered.push(key);
+      });
+    }
+    AI_DEFAULT_ORDER.forEach((aiKey) => {
+      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    AI_KEYS.forEach((aiKey) => {
+      if (!seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    return ordered;
   }
 
-  function getSelectedAIs(enabledAIs) {
-    return AI_KEYS.filter((key) => !!enabledAIs[key]);
+  function applyAiOrderToTabItems(aiOrder) {
+    const normalized = normalizeAiOrder(aiOrder);
+    normalized.forEach((aiKey) => {
+      const item = tabItems[aiKey];
+      if (item && tabStatus) {
+        tabStatus.appendChild(item);
+      }
+    });
+    return normalized;
+  }
+
+  function normalizeEnabledAIs(enabledAIs, aiOrder) {
+    const ordered = normalizeAiOrder(aiOrder);
+    const next = {};
+    ordered.forEach((key) => {
+      next[key] = typeof enabledAIs?.[key] === "boolean" ? enabledAIs[key] : true;
+    });
+    return next;
+  }
+
+  function getDefaultEnabledAIs(aiOrder = AI_DEFAULT_ORDER) {
+    return Object.fromEntries(normalizeAiOrder(aiOrder).map((key) => [key, true]));
+  }
+
+  function getSelectedAIs(enabledAIs, aiOrder = appState.aiOrder) {
+    return normalizeAiOrder(aiOrder).filter((key) => !!enabledAIs[key]);
   }
 
   const appState = {
@@ -77,7 +128,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     digestStatusTone: "info",
     openTabs: {},
     aiStates: Object.fromEntries(AI_KEYS.map((key) => [key, ""])),
-    enabledAIs: getDefaultEnabledAIs(),
+    aiOrder: normalizeAiOrder(AI_DEFAULT_ORDER),
+    enabledAIs: getDefaultEnabledAIs(AI_DEFAULT_ORDER),
     hasPendingQuestion: false,
     allowCollect: false,
     hasFailedItems: false,
@@ -140,9 +192,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   function render() {
     const hasOpenTabs = Object.keys(appState.openTabs || {}).length > 0;
-    const selectedAIs = getSelectedAIs(appState.enabledAIs);
+    const selectedAIs = getSelectedAIs(appState.enabledAIs, appState.aiOrder);
 
-    AI_KEYS.forEach((key) => {
+    appState.aiOrder.forEach((key) => {
       setIndicator(key, getAiIndicatorState(key));
       if (aiCheckboxes[key]) aiCheckboxes[key].checked = !!appState.enabledAIs[key];
     });
@@ -189,8 +241,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       readLocalStorage(lastNoteSnapshotKey),
       storage.getSettings()
     ]);
+    const nextOrder = applyAiOrderToTabItems(settings?.aiOrder);
     populateDigestModelSelect(settings);
-    setState({ hasLastSavedNote: !!snapshot?.notePath });
+    setState({
+      aiOrder: nextOrder,
+      enabledAIs: normalizeEnabledAIs(appState.enabledAIs, nextOrder),
+      hasLastSavedNote: !!snapshot?.notePath
+    });
     return snapshot;
   }
 
@@ -207,7 +264,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   openTabsButton.addEventListener("click", () => {
-    const enabledAIs = getSelectedAIs(appState.enabledAIs);
+    const enabledAIs = getSelectedAIs(appState.enabledAIs, appState.aiOrder);
     if (enabledAIs.length === 0) {
       setState({ statusText: "使用する AI を1つ以上選択してください。" });
       return;
@@ -240,7 +297,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   closeTabsButton.addEventListener("click", () => {
-    const enabledAIs = getSelectedAIs(appState.enabledAIs);
+    const enabledAIs = getSelectedAIs(appState.enabledAIs, appState.aiOrder);
     if (enabledAIs.length === 0) {
       setState({ statusText: "使用する AI を1つ以上選択してください。" });
       return;
@@ -259,16 +316,14 @@ document.addEventListener("DOMContentLoaded", async () => {
       return;
     }
 
-    const enabledAIs = getSelectedAIs(appState.enabledAIs);
+    const enabledAIs = getSelectedAIs(appState.enabledAIs, appState.aiOrder);
     if (enabledAIs.length === 0) {
       setState({ statusText: "使用する AI を1つ以上選択してください。" });
       return;
     }
 
     const isFollowUp = followUpCheckbox.checked;
-    const nextAiStates = Object.fromEntries(
-      AI_KEYS.map((key) => [key, enabledAIs.includes(key) ? "sending" : ""])
-    );
+    const nextAiStates = Object.fromEntries(AI_KEYS.map((key) => [key, enabledAIs.includes(key) ? "sending" : ""]));
     setState({
       busyAction: "sending",
       hasPendingQuestion: true,
@@ -475,7 +530,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   await syncRetryState();
   await syncLastSavedNoteState();
-  setState({ enabledAIs: getDefaultEnabledAIs() });
+  setState({
+    aiOrder: normalizeAiOrder(appState.aiOrder),
+    enabledAIs: getDefaultEnabledAIs(appState.aiOrder)
+  });
   refreshTabStatus();
   promptInput.value = "";
   followUpCheckbox.checked = false;

--- a/ai-prompt-broadcaster/popup.js
+++ b/ai-prompt-broadcaster/popup.js
@@ -37,6 +37,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   const constants = window.MirrorChatConstants || {};
   const AI_KEYS = constants.AI_KEYS ?? ["chatgpt", "claude", "gemini", "grok"];
   const AI_DEFAULT_ORDER = constants.AI_DEFAULT_ORDER ?? ["gemini", "chatgpt", "claude", "grok"];
+  const aiOrderUtils = window.MirrorChatAIOrderUtils;
+  const normalizeAiOrder = aiOrderUtils.normalizeAiOrder;
+  const resolveEnabledAIs = aiOrderUtils.resolveEnabledAIs;
+  const normalizeEnabledAiMap = aiOrderUtils.normalizeEnabledAiMap;
+  const getDefaultEnabledAiMap = aiOrderUtils.getDefaultEnabledAiMap;
   const MESSAGE_TYPES = constants.MESSAGE_TYPES || {};
   const currentTaskKey = constants.STORAGE_KEYS?.CURRENT_TASK ?? "mirrorchatCurrentTask";
   const failedItemsKey = constants.STORAGE_KEYS?.FAILED_ITEMS ?? "mirrorchatFailedItems";
@@ -66,33 +71,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     tabItems[key] = tabStatus?.querySelector('.tab-item[data-ai="' + key + '"]') || null;
   });
 
-  function normalizeAiOrder(rawOrder) {
-    const validKeys = new Set(AI_KEYS);
-    const seen = new Set();
-    const ordered = [];
-    if (Array.isArray(rawOrder)) {
-      rawOrder.forEach((aiKey) => {
-        const key = String(aiKey || "").trim();
-        if (!key || !validKeys.has(key) || seen.has(key)) return;
-        seen.add(key);
-        ordered.push(key);
-      });
-    }
-    AI_DEFAULT_ORDER.forEach((aiKey) => {
-      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    AI_KEYS.forEach((aiKey) => {
-      if (!seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    return ordered;
-  }
-
   function applyAiOrderToTabItems(aiOrder) {
     const normalized = normalizeAiOrder(aiOrder);
     normalized.forEach((aiKey) => {
@@ -105,20 +83,18 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function normalizeEnabledAIs(enabledAIs, aiOrder) {
-    const ordered = normalizeAiOrder(aiOrder);
-    const next = {};
-    ordered.forEach((key) => {
-      next[key] = typeof enabledAIs?.[key] === "boolean" ? enabledAIs[key] : true;
-    });
-    return next;
+    return normalizeEnabledAiMap(enabledAIs, aiOrder);
   }
 
   function getDefaultEnabledAIs(aiOrder = AI_DEFAULT_ORDER) {
-    return Object.fromEntries(normalizeAiOrder(aiOrder).map((key) => [key, true]));
+    return getDefaultEnabledAiMap(aiOrder);
   }
 
   function getSelectedAIs(enabledAIs, aiOrder = appState.aiOrder) {
-    return normalizeAiOrder(aiOrder).filter((key) => !!enabledAIs[key]);
+    return resolveEnabledAIs(
+      normalizeAiOrder(aiOrder).filter((key) => !!enabledAIs[key]),
+      aiOrder
+    );
   }
 
   const appState = {

--- a/ai-prompt-broadcaster/storage.js
+++ b/ai-prompt-broadcaster/storage.js
@@ -8,6 +8,37 @@
   const AI_DEFAULT_ORDER = Array.isArray(constants.AI_DEFAULT_ORDER)
     ? constants.AI_DEFAULT_ORDER
     : ["gemini", "chatgpt", "claude", "grok"];
+  const aiOrderUtils = (typeof self !== "undefined" ? self : window).MirrorChatAIOrderUtils;
+
+  function normalizeAiOrder(rawOrder) {
+    if (aiOrderUtils?.normalizeAiOrder) {
+      return aiOrderUtils.normalizeAiOrder(rawOrder);
+    }
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const ordered = [];
+    if (Array.isArray(rawOrder)) {
+      rawOrder.forEach((aiKey) => {
+        const key = String(aiKey || "").trim();
+        if (!key || !validKeys.has(key) || seen.has(key)) return;
+        seen.add(key);
+        ordered.push(key);
+      });
+    }
+    AI_DEFAULT_ORDER.forEach((aiKey) => {
+      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    AI_KEYS.forEach((aiKey) => {
+      if (!seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    return ordered;
+  }
 
   function cloneAiConfigs(aiConfigs) {
     return Object.fromEntries(
@@ -60,33 +91,6 @@
     return new Promise((resolve) => {
       chrome.storage.sync.set({ [STORAGE_KEY]: nextStored }, () => resolve(resolved));
     });
-  }
-
-  function normalizeAiOrder(rawOrder) {
-    const validKeys = new Set(AI_KEYS);
-    const seen = new Set();
-    const ordered = [];
-    if (Array.isArray(rawOrder)) {
-      rawOrder.forEach((aiKey) => {
-        const key = String(aiKey || "").trim();
-        if (!key || !validKeys.has(key) || seen.has(key)) return;
-        seen.add(key);
-        ordered.push(key);
-      });
-    }
-    AI_DEFAULT_ORDER.forEach((aiKey) => {
-      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    AI_KEYS.forEach((aiKey) => {
-      if (!seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    return ordered;
   }
 
   function sanitizeSettings(settings) {

--- a/ai-prompt-broadcaster/storage.js
+++ b/ai-prompt-broadcaster/storage.js
@@ -2,6 +2,12 @@
   const constants = (typeof self !== "undefined" ? self : window).MirrorChatConstants || {};
   const STORAGE_KEY =
     constants.STORAGE_KEYS?.SETTINGS ?? "mirrorchatSettings";
+  const AI_KEYS = Array.isArray(constants.AI_KEYS)
+    ? constants.AI_KEYS
+    : ["chatgpt", "claude", "gemini", "grok"];
+  const AI_DEFAULT_ORDER = Array.isArray(constants.AI_DEFAULT_ORDER)
+    ? constants.AI_DEFAULT_ORDER
+    : ["gemini", "chatgpt", "claude", "grok"];
 
   function cloneAiConfigs(aiConfigs) {
     return Object.fromEntries(
@@ -10,6 +16,7 @@
   }
 
   const defaultSettings = {
+    aiOrder: [...AI_DEFAULT_ORDER],
     obsidian: {
       baseUrl: "http://127.0.0.1:27123/",
       token: "",
@@ -36,16 +43,57 @@
 
   async function getSettings() {
     const stored = await getStoredSettingsRaw();
-    return mergeDeep(defaultSettings, stored);
+    return sanitizeSettings(mergeDeep(defaultSettings, stored));
   }
 
   async function saveSettings(partial) {
     const stored = await getStoredSettingsRaw();
     const nextStored = mergeForStorage(stored, partial);
-    const resolved = mergeDeep(defaultSettings, nextStored);
+    if (
+      Object.prototype.hasOwnProperty.call(nextStored, "aiOrder") ||
+      Object.prototype.hasOwnProperty.call(partial || {}, "aiOrder") ||
+      Object.prototype.hasOwnProperty.call(stored, "aiOrder")
+    ) {
+      nextStored.aiOrder = normalizeAiOrder(nextStored.aiOrder);
+    }
+    const resolved = sanitizeSettings(mergeDeep(defaultSettings, nextStored));
     return new Promise((resolve) => {
       chrome.storage.sync.set({ [STORAGE_KEY]: nextStored }, () => resolve(resolved));
     });
+  }
+
+  function normalizeAiOrder(rawOrder) {
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const ordered = [];
+    if (Array.isArray(rawOrder)) {
+      rawOrder.forEach((aiKey) => {
+        const key = String(aiKey || "").trim();
+        if (!key || !validKeys.has(key) || seen.has(key)) return;
+        seen.add(key);
+        ordered.push(key);
+      });
+    }
+    AI_DEFAULT_ORDER.forEach((aiKey) => {
+      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    AI_KEYS.forEach((aiKey) => {
+      if (!seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    return ordered;
+  }
+
+  function sanitizeSettings(settings) {
+    return {
+      ...settings,
+      aiOrder: normalizeAiOrder(settings?.aiOrder)
+    };
   }
 
   function mergeDeep(target, source) {

--- a/ai-prompt-broadcaster/tabManager.js
+++ b/ai-prompt-broadcaster/tabManager.js
@@ -1,6 +1,7 @@
 (function () {
   const { AI_KEYS, AI_DEFAULT_ORDER, STORAGE_KEYS } = self.MirrorChatConstants;
   const AI_TAB_IDS_KEY = STORAGE_KEYS.AI_TAB_IDS;
+  const aiOrderUtils = self.MirrorChatAIOrderUtils;
 
   const aiTabIds = {};
   let statusNotifier = () => {};
@@ -40,46 +41,8 @@
     return aiTabIds[aiKey] || null;
   }
 
-  function normalizeAiOrder(rawOrder) {
-    const validKeys = new Set(AI_KEYS);
-    const seen = new Set();
-    const ordered = [];
-    if (Array.isArray(rawOrder)) {
-      rawOrder.forEach((aiKey) => {
-        const key = String(aiKey || "").trim();
-        if (!key || !validKeys.has(key) || seen.has(key)) return;
-        seen.add(key);
-        ordered.push(key);
-      });
-    }
-    (AI_DEFAULT_ORDER || []).forEach((aiKey) => {
-      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    AI_KEYS.forEach((aiKey) => {
-      if (!seen.has(aiKey)) {
-        seen.add(aiKey);
-        ordered.push(aiKey);
-      }
-    });
-    return ordered;
-  }
-
   function resolveTargetAIs(rawEnabledAIs) {
-    if (typeof rawEnabledAIs === "undefined") return normalizeAiOrder(AI_DEFAULT_ORDER);
-    if (!Array.isArray(rawEnabledAIs)) return [];
-    const validKeys = new Set(AI_KEYS);
-    const seen = new Set();
-    const targetAIs = [];
-    rawEnabledAIs.forEach((aiKey) => {
-      const key = String(aiKey || "").trim();
-      if (!key || !validKeys.has(key) || seen.has(key)) return;
-      seen.add(key);
-      targetAIs.push(key);
-    });
-    return targetAIs;
+    return aiOrderUtils.resolveEnabledAIs(rawEnabledAIs, AI_DEFAULT_ORDER);
   }
 
   async function openAITabs(settings, enabledAIs) {

--- a/ai-prompt-broadcaster/tabManager.js
+++ b/ai-prompt-broadcaster/tabManager.js
@@ -1,5 +1,5 @@
 (function () {
-  const { AI_KEYS, STORAGE_KEYS } = self.MirrorChatConstants;
+  const { AI_KEYS, AI_DEFAULT_ORDER, STORAGE_KEYS } = self.MirrorChatConstants;
   const AI_TAB_IDS_KEY = STORAGE_KEYS.AI_TAB_IDS;
 
   const aiTabIds = {};
@@ -40,10 +40,46 @@
     return aiTabIds[aiKey] || null;
   }
 
+  function normalizeAiOrder(rawOrder) {
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const ordered = [];
+    if (Array.isArray(rawOrder)) {
+      rawOrder.forEach((aiKey) => {
+        const key = String(aiKey || "").trim();
+        if (!key || !validKeys.has(key) || seen.has(key)) return;
+        seen.add(key);
+        ordered.push(key);
+      });
+    }
+    (AI_DEFAULT_ORDER || []).forEach((aiKey) => {
+      if (validKeys.has(aiKey) && !seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    AI_KEYS.forEach((aiKey) => {
+      if (!seen.has(aiKey)) {
+        seen.add(aiKey);
+        ordered.push(aiKey);
+      }
+    });
+    return ordered;
+  }
+
   function resolveTargetAIs(rawEnabledAIs) {
-    if (typeof rawEnabledAIs === "undefined") return [...AI_KEYS];
+    if (typeof rawEnabledAIs === "undefined") return normalizeAiOrder(AI_DEFAULT_ORDER);
     if (!Array.isArray(rawEnabledAIs)) return [];
-    return AI_KEYS.filter((key) => rawEnabledAIs.includes(key));
+    const validKeys = new Set(AI_KEYS);
+    const seen = new Set();
+    const targetAIs = [];
+    rawEnabledAIs.forEach((aiKey) => {
+      const key = String(aiKey || "").trim();
+      if (!key || !validKeys.has(key) || seen.has(key)) return;
+      seen.add(key);
+      targetAIs.push(key);
+    });
+    return targetAIs;
   }
 
   async function openAITabs(settings, enabledAIs) {

--- a/e2e/tests/mirrorchat.spec.js
+++ b/e2e/tests/mirrorchat.spec.js
@@ -28,6 +28,11 @@ test.describe("MirrorChat 拡張機能", () => {
     await expect(aiCheckboxes.nth(1)).toBeChecked();
     await expect(aiCheckboxes.nth(2)).toBeChecked();
     await expect(aiCheckboxes.nth(3)).toBeChecked();
+
+    const aiOrder = await page.locator(".tab-item .tab-name").evaluateAll((nodes) =>
+      nodes.map((node) => node.textContent?.trim() || "")
+    );
+    expect(aiOrder).toEqual(["Gemini", "ChatGPT", "Claude", "Grok"]);
   });
 
   test("使用するAIを全て外すとサイトを開けない", async ({ page, extensionId }) => {
@@ -218,6 +223,39 @@ test.describe("MirrorChat 拡張機能", () => {
     await expect(page.locator("#openrouter-api-key")).toHaveValue("sk-or-test");
     await page.locator("details.advanced-settings").nth(0).locator("summary").click();
     await expect(page.locator("#openrouter-preferred-model")).toHaveValue("google/gemma-3-27b-it:free");
+  });
+
+  test("AIモデル順を保存すると options と popup の順番に反映される", async ({ page, extensionId }) => {
+    await page.goto(`chrome-extension://${extensionId}/options.html`);
+
+    // 既定順: Gemini, ChatGPT, Claude, Grok
+    const moveGrokUp = page.locator("#ai-order-list .ai-order-item").filter({ hasText: "Grok" }).locator("button[data-action='up']");
+    await moveGrokUp.click();
+    await moveGrokUp.click();
+    await moveGrokUp.click();
+
+    await page.locator("#save-button").click();
+    await expect(page.locator("#status")).toContainText("保存しました", {
+      timeout: 5_000,
+    });
+
+    await page.reload();
+
+    const optionOrder = await page.locator("#ai-order-list .ai-order-name").evaluateAll((nodes) =>
+      nodes.map((node) => node.textContent?.trim() || "")
+    );
+    expect(optionOrder).toEqual(["Grok", "Gemini", "ChatGPT", "Claude"]);
+
+    const configOrder = await page.locator("#ai-config-list .ai-config h3").evaluateAll((nodes) =>
+      nodes.map((node) => node.textContent?.trim() || "")
+    );
+    expect(configOrder).toEqual(["Grok", "Gemini", "ChatGPT", "Claude"]);
+
+    await page.goto(`chrome-extension://${extensionId}/popup.html?standalone=1`);
+    const popupOrder = await page.locator(".tab-item .tab-name").evaluateAll((nodes) =>
+      nodes.map((node) => node.textContent?.trim() || "")
+    );
+    expect(popupOrder).toEqual(["Grok", "Gemini", "ChatGPT", "Claude"]);
   });
 
   test("直近ノートがあれば再保存と digest再生成を実行できる", async ({ page, extensionId }) => {


### PR DESCRIPTION
## 概要
- issue #28 の AI モデル順変更を改めて main に取り込む
- 既定順を Gemini -> ChatGPT -> Claude -> Grok に変更
- 設定画面から並び替え可能にし、popup・タブを開く順・送信順・回答取得順へ反映

## 変更内容
- `aiOrder` 設定の追加と後方互換のための正規化
- popup / background / tabManager / options で AI 順序を一貫して利用
- issue 28 実装後に AI 順序ロジックを共通ユーティリティへ集約

## 動作確認
- `pnpm lint`
- `cd e2e && pnpm test --grep "ポップアップが表示され、タイトルが正しい|AIモデル順を保存すると options と popup の順番に反映される"`

## 補足
- 以前の PR #30 は GitHub 上では merged 扱いのままですが、main を巻き戻したため実コードは未反映でした
- この PR は実際に main へ取り込むための再作成です
