### PR TITLE
feat(digest): add OpenCode Zen as alternative digest provider

### DIFF
--- a/ai-prompt-broadcaster/background.js
+++ b/ai-prompt-broadcaster/background.js
@@ -8,6 +8,8 @@ importScripts(
   "obsidianClient.js",
   "openRouterFreeModels.js",
   "openRouterClient.js",
+  "openCodeZenFreeModels.js",
+  "openCodeZenClient.js",
   "digestService.js",
   "taskQueue.js",
   "errorRetry.js",
@@ -109,11 +111,12 @@ async function runDigestFollowUp({ question, results, settings, notePath, isFoll
 
   if (Object.keys(openRouterSettingsPatch).length > 0) {
     try {
+      const providerKey = digestResult.providerName === "opencodezen" ? "opencodezen" : "openrouter";
       await self.MirrorChatStorage.saveSettings({
-        openrouter: openRouterSettingsPatch
+        [providerKey]: openRouterSettingsPatch
       });
     } catch (error) {
-      console.warn("MirrorChat: digest 用 OpenRouter 設定の保存に失敗しました:", error);
+      console.warn("MirrorChat: digest 用 provider 設定の保存に失敗しました:", error);
     }
   }
 

--- a/ai-prompt-broadcaster/digestService.js
+++ b/ai-prompt-broadcaster/digestService.js
@@ -1,6 +1,8 @@
 (function () {
   const openRouterClient = self.MirrorChatOpenRouterClient;
-  const freeModelSelector = self.MirrorChatOpenRouterFreeModels;
+  const openRouterFreeModelSelector = self.MirrorChatOpenRouterFreeModels;
+  const openCodeZenClient = self.MirrorChatOpenCodeZenClient;
+  const openCodeZenFreeModelSelector = self.MirrorChatOpenCodeZenFreeModels;
   const DIGEST_MODEL_TIMEOUT_MS = 30000;
   const DIGEST_CATALOG_TIMEOUT_MS = 8000;
   const DIGEST_RECENT_FAILURE_COOLDOWN_MS = {
@@ -22,21 +24,22 @@
     if (kind === "rateLimit") return `${modelId} はレート制限のため利用できません。別モデルへ切り替えます。`;
     if (kind === "noProviders") return `${modelId} は利用可能な provider がありません。別モデルへ切り替えます。`;
     if (kind === "invalidFormat") return `${modelId} の出力が digest 形式を満たしませんでした。別モデルへ切り替えます: ${String(message || "形式不正")}`;
+    if (kind === "invalidModel") return `${modelId} は利用できないモデルです。別モデルへ切り替えます。`;
     return `${modelId} で失敗しました: ${String(message || "不明なエラー")}`;
   }
 
-  function summarizeCatalogError({ kind, message }) {
+  function summarizeCatalogError({ kind, message, providerName }) {
     if (kind === "timeout") {
-      return `free候補取得が ${Math.round(DIGEST_CATALOG_TIMEOUT_MS / 1000)} 秒でタイムアウトしました。保存済み候補で続行します。`;
+      return `${providerName} free候補取得が ${Math.round(DIGEST_CATALOG_TIMEOUT_MS / 1000)} 秒でタイムアウトしました。保存済み候補で続行します。`;
     }
     if (kind === "rateLimit") {
-      return "free候補取得がレート制限にかかりました。保存済み候補で続行します。";
+      return `${providerName} free候補取得がレート制限にかかりました。保存済み候補で続行します。`;
     }
-    return `free候補取得に失敗しました: ${String(message || "不明なエラー")}`;
+    return `${providerName} free候補取得に失敗しました: ${String(message || "不明なエラー")}`;
   }
 
   function isDigestEnabled(settings) {
-    return !!settings?.openrouter?.enableDigest;
+    return !!settings?.digestProvider;
   }
 
   function buildDigestFailureText(message) {
@@ -75,11 +78,11 @@
     return `### ${name}\n(取得できませんでした)${errorText ? `\n理由: ${errorText}` : ""}`;
   }
 
-  function buildDigestBody({ digestMarkdown, modelId }) {
+  function buildDigestBody({ digestMarkdown, modelId, providerName }) {
     return [
       digestMarkdown,
       "",
-      `<sub>要約モデル: openrouter/${modelId}</sub>`
+      `<sub>要約モデル: ${providerName}/${modelId}</sub>`
     ].join("\n");
   }
 
@@ -304,22 +307,42 @@
     await onProgress(payload);
   }
 
-  function buildRunContext({ prompt, settings, preferredModel, requestedModel, apiKey, timeoutMs, catalogTimeoutMs, attemptLimit }) {
-    const resolvedApiKey = String(apiKey || settings?.openrouter?.apiKey || "").trim();
-    const resolvedPreferredModel = String(preferredModel || settings?.openrouter?.preferredModel || "").trim();
-    const resolvedRequestedModel = String(requestedModel || "").trim();
-    const resolvedRecentFailures = normalizeRecentDigestFailures(settings?.openrouter?.recentDigestFailures);
+  function resolveProvider(settings) {
+    const provider = String(settings?.digestProvider || "openrouter").trim().toLowerCase();
+    if (provider === "opencodezen") {
+      return {
+        name: "opencodezen",
+        client: openCodeZenClient,
+        freeModelSelector: openCodeZenFreeModelSelector,
+        catalogEndpoint: "/models",
+        apiKey: String(settings?.opencodezen?.apiKey || "").trim(),
+        preferredModel: String(settings?.opencodezen?.preferredModel || "").trim(),
+        freeModelCandidatesOverride: settings?.opencodezen?.freeModelCandidatesOverride,
+        recentDigestFailures: normalizeRecentDigestFailures(settings?.opencodezen?.recentDigestFailures)
+      };
+    }
+    // default: openrouter
+    return {
+      name: "openrouter",
+      client: openRouterClient,
+      freeModelSelector: openRouterFreeModelSelector,
+      catalogEndpoint: "/models",
+      apiKey: String(settings?.openrouter?.apiKey || "").trim(),
+      preferredModel: String(settings?.openrouter?.preferredModel || "").trim(),
+      freeModelCandidatesOverride: settings?.openrouter?.freeModelCandidatesOverride,
+      recentDigestFailures: normalizeRecentDigestFailures(settings?.openrouter?.recentDigestFailures)
+    };
+  }
+
+  function buildRunContext({ prompt, apiKey, timeoutMs, catalogTimeoutMs, attemptLimit }) {
+    const resolvedApiKey = String(apiKey || "").trim();
     return {
       resolvedApiKey,
-      resolvedPreferredModel,
-      resolvedRequestedModel,
-      resolvedRecentFailures,
       systemPrompt: String(prompt?.systemPrompt || ""),
       userPrompt: String(prompt?.userPrompt || ""),
       candidateResolution: {
-        source: resolvedRequestedModel ? "requested" : "stored",
-        preferredModel: resolvedPreferredModel,
-        requestedModel: resolvedRequestedModel,
+        source: "stored",
+        requestedModel: "",
         attemptedCandidates: [],
         coolingDownCandidates: [],
         runtime: {
@@ -333,62 +356,61 @@
   }
 
   async function resolveRunCandidates({
-    settings,
+    provider,
     fetchImpl,
     onProgress,
     resolvedApiKey,
-    resolvedPreferredModel,
-    resolvedRequestedModel,
     catalogTimeoutMs,
-    candidateResolution
+    candidateResolution,
+    requestedModel
   }) {
-    let resolvedCandidates = settings?.openrouter?.freeModelCandidatesOverride;
+    // requestedModel 指定時は catalog 取得をスキップして即座に返す
+    if (requestedModel) {
+      candidateResolution.source = "requested";
+      candidateResolution.requestedModel = requestedModel;
+      return { resolvedCandidates: [requestedModel], refreshedCandidates: [], refreshedStats: {} };
+    }
+
+    const resolvedCandidates = provider.freeModelCandidatesOverride || [];
     let refreshedCandidates = [];
     let refreshedStats = {};
-
-    if (resolvedRequestedModel) {
-      return {
-        resolvedCandidates: [resolvedRequestedModel],
-        refreshedCandidates,
-        refreshedStats
-      };
-    }
 
     try {
       await emitProgress(onProgress, {
         stage: "catalog-start",
-        message: "digest の free候補を確認しています..."
+        message: `${provider.name} の free候補を確認しています...`
       });
 
-      const catalog = await openRouterClient.fetchModelsCatalog({
+      const catalog = await provider.client.fetchModelsCatalog({
         apiKey: resolvedApiKey,
         fetchImpl,
         timeoutMs: catalogTimeoutMs
       });
-      const refreshed = freeModelSelector.refreshDigestFreeModels({
+      const refreshed = provider.freeModelSelector.refreshDigestFreeModels({
         catalog,
-        preferredModel: resolvedPreferredModel
+        preferredModel: provider.preferredModel
       });
-      resolvedCandidates = refreshed.candidates;
       refreshedCandidates = refreshed.candidates;
       refreshedStats = refreshed.stats || {};
       candidateResolution.source = "catalog";
-      return { resolvedCandidates, refreshedCandidates, refreshedStats };
+      return { resolvedCandidates: refreshedCandidates, refreshedCandidates, refreshedStats };
     } catch (error) {
-      const kind = freeModelSelector.classifyOpenRouterError(error);
+      const kind = provider.freeModelSelector.classifyOpenCodeZenError
+        ? provider.freeModelSelector.classifyOpenCodeZenError(error)
+        : provider.freeModelSelector.classifyOpenRouterError(error);
       const errorText = toErrorText(error);
       candidateResolution.source = "stored";
       candidateResolution.catalogError = {
         kind,
         error: errorText,
-        errorMessage: summarizeCatalogError({ kind, message: errorText })
+        errorMessage: summarizeCatalogError({ kind, message: errorText, providerName: provider.name })
       };
       await emitProgress(onProgress, {
         stage: "catalog-failure",
         kind,
         error: errorText,
-        message: "free候補の取得に失敗したため、保存済み候補で digest を続行します。",
-        errorMessage: candidateResolution.catalogError.errorMessage
+        message: `${provider.name} free候補の取得に失敗したため、保存済み候補で digest を続行します。`,
+        errorMessage: summarizeCatalogError({ kind, message: errorText, providerName: provider.name })
       });
       return { resolvedCandidates, refreshedCandidates, refreshedStats };
     }
@@ -399,28 +421,21 @@
     settings,
     fetchImpl,
     onProgress,
-    preferredModel,
     requestedModel,
-    apiKey,
     timeoutMs = DIGEST_MODEL_TIMEOUT_MS,
     catalogTimeoutMs = DIGEST_CATALOG_TIMEOUT_MS,
     attemptLimit = 0
   }) {
+    const provider = resolveProvider(settings);
     const context = buildRunContext({
       prompt,
-      settings,
-      preferredModel,
-      requestedModel,
-      apiKey,
+      apiKey: provider.apiKey,
       timeoutMs,
       catalogTimeoutMs,
       attemptLimit
     });
     const {
       resolvedApiKey,
-      resolvedPreferredModel,
-      resolvedRequestedModel,
-      resolvedRecentFailures,
       systemPrompt,
       userPrompt,
       candidateResolution
@@ -429,12 +444,12 @@
     if (!resolvedApiKey) {
       return {
         ok: false,
-        error: "OpenRouter API キーが設定されていません",
+        error: `${provider.name} の API キーが設定されていません`,
         attempts: [],
         attemptResults: [],
         refreshedCandidates: [],
         refreshedStats: {},
-        recentDigestFailures: resolvedRecentFailures,
+        recentDigestFailures: provider.recentDigestFailures,
         candidateResolution
       };
     }
@@ -444,28 +459,23 @@
       refreshedCandidates,
       refreshedStats
     } = await resolveRunCandidates({
-      settings,
+      provider,
       fetchImpl,
       onProgress,
       resolvedApiKey,
-      resolvedPreferredModel,
-      resolvedRequestedModel,
       catalogTimeoutMs,
-      candidateResolution
+      candidateResolution,
+      requestedModel
     });
 
-    const orderedCandidates = resolvedRequestedModel
-      ? [resolvedRequestedModel]
-      : freeModelSelector.buildCandidateList({
-          preferredModel: resolvedPreferredModel,
-          candidates: resolvedCandidates
-        });
-    const reorderedCandidates = resolvedRequestedModel
-      ? orderedCandidates
-      : reorderCandidatesByRecentFailures(orderedCandidates, resolvedRecentFailures);
+    const orderedCandidates = provider.freeModelSelector.buildCandidateList({
+      preferredModel: provider.preferredModel,
+      candidates: resolvedCandidates
+    });
+    const reorderedCandidates = reorderCandidatesByRecentFailures(orderedCandidates, provider.recentDigestFailures);
     const attemptCandidates = limitAttemptCandidates(reorderedCandidates, attemptLimit);
     candidateResolution.attemptedCandidates = attemptCandidates.slice();
-    candidateResolution.coolingDownCandidates = collectCoolingDownCandidates(orderedCandidates, resolvedRecentFailures);
+    candidateResolution.coolingDownCandidates = collectCoolingDownCandidates(orderedCandidates, provider.recentDigestFailures);
 
     const attempts = [];
     const attemptResults = [];
@@ -482,12 +492,13 @@
               modelId: previousFailure.modelId,
               kind: previousFailure.kind,
               message: previousFailure.error,
-              timeoutMs
+              timeoutMs,
+              providerName: provider.name
             })
           : ""
       });
 
-      const diagnostic = await openRouterClient.diagnoseChatCompletion({
+      const diagnostic = await provider.client.diagnoseChatCompletion({
         apiKey: resolvedApiKey,
         modelId,
         systemPrompt,
@@ -518,7 +529,7 @@
             kind: failure.kind,
             error: failure.error,
             message: `digest を生成しています... (${modelId})`,
-            errorMessage: summarizeAttemptError({ modelId, kind: failure.kind, message: failure.error, timeoutMs })
+            errorMessage: summarizeAttemptError({ modelId, kind: failure.kind, message: failure.error, timeoutMs, providerName: provider.name })
           });
           lastError = failure.error;
           continue;
@@ -535,12 +546,13 @@
           ok: true,
           text: diagnostic.text,
           modelId,
+          providerName: provider.name,
           attempts,
           attemptResults,
           refreshedCandidates,
           refreshedStats,
           recentDigestFailures: updateRecentDigestFailures({
-            recentFailures: resolvedRecentFailures,
+            recentFailures: provider.recentDigestFailures,
             attempts,
             successModelId: modelId
           }),
@@ -548,10 +560,11 @@
         };
       }
 
+      const classifyError = provider.freeModelSelector.classifyOpenCodeZenError || provider.freeModelSelector.classifyOpenRouterError;
       const failure = {
         modelId,
-        kind: freeModelSelector.classifyOpenRouterError(new Error(diagnostic.error || "OpenRouter request failed")),
-        error: diagnostic.error || "OpenRouter request failed"
+        kind: classifyError(new Error(diagnostic.error || "request failed")),
+        error: diagnostic.error || "request failed"
       };
       attempts.push(failure);
       attemptResults.push({
@@ -567,20 +580,20 @@
         kind: failure.kind,
         error: failure.error,
         message: `digest を生成しています... (${modelId})`,
-        errorMessage: summarizeAttemptError({ modelId, kind: failure.kind, message: failure.error, timeoutMs })
+        errorMessage: summarizeAttemptError({ modelId, kind: failure.kind, message: failure.error, timeoutMs, providerName: provider.name })
       });
       lastError = failure.error;
     }
 
     return {
       ok: false,
-      error: lastError || "No working OpenRouter free models",
+      error: lastError || `${provider.name} の free モデル全てで失敗しました`,
       attempts,
       attemptResults,
       refreshedCandidates,
       refreshedStats,
       recentDigestFailures: updateRecentDigestFailures({
-        recentFailures: resolvedRecentFailures,
+        recentFailures: provider.recentDigestFailures,
         attempts,
         successModelId: ""
       }),
@@ -610,9 +623,11 @@
       ok: true,
       digest: buildDigestBody({
         digestMarkdown: selection.text,
-        modelId: selection.modelId
+        modelId: selection.modelId,
+        providerName: selection.providerName
       }),
       modelId: selection.modelId,
+      providerName: selection.providerName,
       attempts: selection.attempts,
       refreshedCandidates: selection.refreshedCandidates,
       refreshedStats: selection.refreshedStats,
@@ -628,6 +643,7 @@
     validateDigestMarkdown,
     buildDigestDiagnosticPrompt,
     runDigestPrompt,
-    generateDigest
+    generateDigest,
+    resolveProvider
   };
 })();

--- a/ai-prompt-broadcaster/digestService.js
+++ b/ai-prompt-broadcaster/digestService.js
@@ -9,6 +9,7 @@
     rateLimit: 10 * 60 * 1000,
     timeout: 5 * 60 * 1000,
     noProviders: 30 * 60 * 1000,
+    invalidModel: 12 * 60 * 60 * 1000,
     invalidFormat: 12 * 60 * 60 * 1000,
     other: 2 * 60 * 1000
   };
@@ -39,7 +40,7 @@
   }
 
   function isDigestEnabled(settings) {
-    return !!settings?.digestProvider;
+    return !!settings?.digestProvider || !!settings?.openrouter?.enableDigest;
   }
 
   function buildDigestFailureText(message) {

--- a/ai-prompt-broadcaster/manifest.json
+++ b/ai-prompt-broadcaster/manifest.json
@@ -24,17 +24,18 @@
     "clipboardWrite",
     "offscreen"
   ],
-  "host_permissions": [
-    "*://chatgpt.com/*",
-    "*://claude.ai/*",
-    "*://gemini.google.com/*",
-    "*://grok.com/*",
-    "https://openrouter.ai/*",
-    "http://127.0.0.1/*",
-    "https://127.0.0.1/*",
-    "http://localhost/*",
-    "https://localhost/*"
-  ],
+    "host_permissions": [
+      "*://chatgpt.com/*",
+      "*://claude.ai/*",
+      "*://gemini.google.com/*",
+      "*://grok.com/*",
+      "https://openrouter.ai/*",
+      "https://opencode.ai/*",
+      "http://127.0.0.1/*",
+      "https://127.0.0.1/*",
+      "http://localhost/*",
+      "https://localhost/*"
+    ],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   }

--- a/ai-prompt-broadcaster/obsidianStorage.js
+++ b/ai-prompt-broadcaster/obsidianStorage.js
@@ -64,7 +64,9 @@
   }
 
   function buildInitialDigestText(settings) {
-    return settings.openrouter?.enableDigest ? DIGEST_PENDING_TEXT : DIGEST_DISABLED_TEXT;
+    return settings?.digestProvider || settings?.openrouter?.enableDigest
+      ? DIGEST_PENDING_TEXT
+      : DIGEST_DISABLED_TEXT;
   }
 
   function buildQuestionAnswersContent(question, results, settings) {

--- a/ai-prompt-broadcaster/openCodeZenClient.js
+++ b/ai-prompt-broadcaster/openCodeZenClient.js
@@ -1,0 +1,261 @@
+(function () {
+  const DEFAULT_BASE_URL = "https://opencode.ai/zen/v1";
+  const DEFAULT_TIMEOUT_MS = 30000;
+  const DEFAULT_MAX_TOKENS = 8192;
+  const DEFAULT_TEMPERATURE = 0.2;
+
+  async function requestJson({ url, apiKey, fetchImpl = fetch, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const headers = { Accept: "application/json" };
+      if (apiKey) {
+        headers.Authorization = `Bearer ${apiKey}`;
+      }
+      const response = await fetchImpl(url, {
+        method: "GET",
+        headers,
+        signal: controller.signal
+      });
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`OpenCode Zen HTTP ${response.status}: ${errorText || response.statusText}`);
+      }
+      return await response.json();
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw new Error(`OpenCode Zen request timed out after ${timeoutMs}ms`, { cause: error });
+      }
+      throw error;
+    } finally {
+      clearTimeout(timerId);
+    }
+  }
+
+  function extractTextFromMessageContent(content) {
+    if (typeof content === "string") return content.trim();
+    if (!Array.isArray(content)) return "";
+    return content
+      .map((part) => {
+        if (!part || typeof part !== "object") return "";
+        if (typeof part.text === "string") return part.text;
+        return "";
+      })
+      .join("\n")
+      .trim();
+  }
+
+  function buildChatCompletionRequestBody({ modelId, systemPrompt, userPrompt }) {
+    return {
+      model: modelId,
+      temperature: DEFAULT_TEMPERATURE,
+      max_tokens: DEFAULT_MAX_TOKENS,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt }
+      ]
+    };
+  }
+
+  function analyzeChatCompletionPayload(payload) {
+    const choice = payload?.choices?.[0];
+    const topLevelErrorMessage = typeof payload?.error?.message === "string"
+      ? payload.error.message.trim()
+      : "";
+    const rawContent = choice?.message?.content;
+    const contentKind = Array.isArray(rawContent)
+      ? "array"
+      : rawContent === null
+        ? "null"
+        : typeof rawContent;
+    const text = extractTextFromMessageContent(rawContent);
+    const finishReason = typeof choice?.finish_reason === "string" ? choice.finish_reason.trim() : "";
+    const choiceErrorMessage = typeof choice?.error?.message === "string"
+      ? choice.error.message.trim()
+      : "";
+    const reasoning = typeof choice?.message?.reasoning === "string"
+      ? choice.message.reasoning.trim()
+      : "";
+    const reasoningTokensRaw = payload?.usage?.completion_tokens_details?.reasoning_tokens;
+    const reasoningTokens = typeof reasoningTokensRaw === "number" && Number.isFinite(reasoningTokensRaw)
+      ? reasoningTokensRaw
+      : null;
+    const finishReasonSuffix = finishReason ? ` (finish_reason: ${finishReason})` : "";
+
+    let error = "";
+    if (!choice) {
+      error = topLevelErrorMessage
+        ? `OpenCode Zen returned an error payload: ${topLevelErrorMessage}`
+        : "OpenCode Zen returned no completion choices";
+    } else if (choiceErrorMessage) {
+      error = `OpenCode Zen provider error: ${choiceErrorMessage}`;
+    } else if (!text && reasoning) {
+      error = `OpenCode Zen returned reasoning without final text${finishReasonSuffix}`;
+    } else if (!text && reasoningTokens !== null && reasoningTokens > 0) {
+      error = `OpenCode Zen returned no final text after consuming ${reasoningTokens} reasoning tokens${finishReasonSuffix}`;
+    } else if (!text) {
+      error = `OpenCode Zen returned an empty completion${finishReasonSuffix}`;
+    }
+
+    return {
+      ok: Boolean(text) && !error,
+      error,
+      text,
+      contentKind,
+      finishReason,
+      choiceErrorMessage,
+      topLevelErrorMessage,
+      reasoning,
+      reasoningTokens,
+      model: typeof payload?.model === "string" ? payload.model : "",
+      provider: typeof payload?.provider === "string" ? payload.provider : "",
+      usage: payload?.usage && typeof payload.usage === "object" ? payload.usage : null
+    };
+  }
+
+  async function diagnoseChatCompletion({
+    apiKey,
+    modelId,
+    systemPrompt,
+    userPrompt,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    baseUrl = DEFAULT_BASE_URL
+  }) {
+    const controller = new AbortController();
+    const timerId = setTimeout(() => controller.abort(), timeoutMs);
+    const requestBody = buildChatCompletionRequestBody({ modelId, systemPrompt, userPrompt });
+    const request = {
+      modelId,
+      timeoutMs,
+      maxTokens: requestBody.max_tokens,
+      temperature: requestBody.temperature,
+      systemPromptLength: String(systemPrompt || "").length,
+      userPromptLength: String(userPrompt || "").length
+    };
+
+    try {
+      const response = await fetchImpl(`${baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          Accept: "application/json"
+        },
+        body: JSON.stringify(requestBody),
+        signal: controller.signal
+      });
+      const responseSummary = {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText || ""
+      };
+
+      const rawText = await response.text();
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: `OpenCode Zen HTTP ${response.status}: ${rawText || response.statusText}`,
+          text: "",
+          payload: null,
+          rawText,
+          analysis: null,
+          request,
+          response: responseSummary
+        };
+      }
+
+      let payload = null;
+      try {
+        payload = rawText ? JSON.parse(rawText) : null;
+      } catch (error) {
+        return {
+          ok: false,
+          error: `OpenCode Zen returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+          text: "",
+          payload: null,
+          rawText,
+          analysis: null,
+          request,
+          response: responseSummary
+        };
+      }
+
+      const analysis = analyzeChatCompletionPayload(payload);
+      return {
+        ok: analysis.ok,
+        error: analysis.error,
+        text: analysis.text,
+        payload,
+        rawText,
+        analysis,
+        request,
+        response: responseSummary
+      };
+    } catch (error) {
+      const message = error?.name === "AbortError"
+        ? `OpenCode Zen request timed out after ${timeoutMs}ms`
+        : error instanceof Error
+          ? error.message
+          : String(error);
+      return {
+        ok: false,
+        error: message,
+        text: "",
+        payload: null,
+        rawText: "",
+        analysis: null,
+        request,
+        response: null
+      };
+    } finally {
+      clearTimeout(timerId);
+    }
+  }
+
+  async function requestChatCompletion({
+    apiKey,
+    modelId,
+    systemPrompt,
+    userPrompt,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    baseUrl = DEFAULT_BASE_URL
+  }) {
+    const diagnostic = await diagnoseChatCompletion({
+      apiKey,
+      modelId,
+      systemPrompt,
+      userPrompt,
+      fetchImpl,
+      timeoutMs,
+      baseUrl
+    });
+    if (!diagnostic.ok) {
+      throw new Error(diagnostic.error || "OpenCode Zen request failed");
+    }
+    return diagnostic.text;
+  }
+
+  async function fetchModelsCatalog({
+    apiKey,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    baseUrl = DEFAULT_BASE_URL
+  }) {
+    const payload = await requestJson({
+      url: `${baseUrl}/models`,
+      apiKey,
+      fetchImpl,
+      timeoutMs
+    });
+    return Array.isArray(payload?.data) ? payload.data : [];
+  }
+
+  self.MirrorChatOpenCodeZenClient = {
+    diagnoseChatCompletion,
+    requestChatCompletion,
+    fetchModelsCatalog
+  };
+})();

--- a/ai-prompt-broadcaster/openCodeZenFreeModels.js
+++ b/ai-prompt-broadcaster/openCodeZenFreeModels.js
@@ -1,0 +1,264 @@
+(function () {
+  const DEFAULT_MAX_AGE_DAYS = 180;
+
+  // OpenCode Zen の free モデルを優先順に定義（明示的なリスト）
+  const COLLECTION_PRIORITY_MODELS = [
+    "big-pickle",
+    "trinity-large-preview-free",
+    "minimax-m2.5-free",
+    "nemotron-3-super-free"
+  ];
+
+  const DEFAULT_DIGEST_FREE_MODELS = [
+    "big-pickle",
+    "trinity-large-preview-free",
+    "minimax-m2.5-free",
+    "nemotron-3-super-free"
+  ];
+
+  const COLLECTION_PRIORITY_INDEX = new Map(
+    COLLECTION_PRIORITY_MODELS.map((modelId, index) => [modelId, index])
+  );
+
+  function normalizeCandidateList(candidates) {
+    const unique = new Set();
+    const normalized = [];
+    for (const candidate of candidates || []) {
+      const modelId = String(candidate || "").trim();
+      if (!modelId || unique.has(modelId)) continue;
+      unique.add(modelId);
+      normalized.push(modelId);
+    }
+    return normalized;
+  }
+
+  function getDefaultDigestFreeModels() {
+    return [...DEFAULT_DIGEST_FREE_MODELS];
+  }
+
+  function getCollectionPriorityModels() {
+    return [...COLLECTION_PRIORITY_MODELS];
+  }
+
+  function getCollectionPriorityIndex(modelId) {
+    return COLLECTION_PRIORITY_INDEX.has(modelId)
+      ? COLLECTION_PRIORITY_INDEX.get(modelId)
+      : Number.POSITIVE_INFINITY;
+  }
+
+  function buildCandidateList({ preferredModel, candidates } = {}) {
+    const base = Array.isArray(candidates) && candidates.length > 0
+      ? candidates
+      : getDefaultDigestFreeModels();
+    const preferred = String(preferredModel || "").trim();
+    return normalizeCandidateList(preferred ? [preferred, ...base] : base);
+  }
+
+  function buildKnownFreeModelList({ preferredModel, candidates } = {}) {
+    const preferred = String(preferredModel || "").trim();
+    const provided = Array.isArray(candidates) ? candidates : [];
+    return normalizeCandidateList([
+      preferred,
+      ...provided,
+      ...getCollectionPriorityModels(),
+      ...getDefaultDigestFreeModels()
+    ]);
+  }
+
+  function buildSelectOptions({ preferredModel, candidates } = {}) {
+    const ordered = buildKnownFreeModelList({ preferredModel, candidates });
+    const options = [{ value: "", label: "自動選択（既定の free モデルから選ぶ）" }];
+    for (const modelId of ordered) {
+      options.push({ value: modelId, label: modelId });
+    }
+    return options;
+  }
+
+  function summarizeModelAvailability({ preferredModel, candidates, stats, lastRefreshAt } = {}) {
+    const normalizedCandidates = Array.isArray(candidates) ? normalizeCandidateList(candidates) : [];
+    const normalizedStats = stats && typeof stats === "object" ? stats : {};
+    const summary = {
+      digestCandidateCount: buildCandidateList({
+        preferredModel,
+        candidates: normalizedCandidates
+      }).length,
+      selectableCount: buildKnownFreeModelList({
+        preferredModel,
+        candidates: normalizedCandidates
+      }).length,
+      freeCount: Number.isFinite(normalizedStats.freeCount) ? normalizedStats.freeCount : null,
+      catalogCount: Number.isFinite(normalizedStats.catalogCount) ? normalizedStats.catalogCount : null,
+      digestCompatibleCount: Number.isFinite(normalizedStats.digestCompatibleCount)
+        ? normalizedStats.digestCompatibleCount
+        : null,
+      lastRefreshAt: String(lastRefreshAt || "").trim()
+    };
+    summary.hasRefreshInfo =
+      normalizedCandidates.length > 0 ||
+      !!summary.lastRefreshAt ||
+      summary.freeCount !== null ||
+      summary.catalogCount !== null ||
+      summary.digestCompatibleCount !== null;
+    return summary;
+  }
+
+  function classifyOpenCodeZenError(error) {
+    const message = error instanceof Error ? error.message : String(error || "");
+    const lower = message.toLowerCase();
+    if (
+      lower.includes("rate limit") ||
+      lower.includes("429") ||
+      lower.includes("too many requests")
+    ) {
+      return "rateLimit";
+    }
+    if (lower.includes("no allowed providers are available")) {
+      return "noProviders";
+    }
+    if (lower.includes("timed out") || lower.includes("timeout") || lower.includes("aborted")) {
+      return "timeout";
+    }
+    if (
+      lower.includes("model") &&
+      (lower.includes("not supported") || lower.includes("not found") || lower.includes("invalid"))
+    ) {
+      return "invalidModel";
+    }
+    return "other";
+  }
+
+  function toModelEntry(entry) {
+    if (!entry || typeof entry !== "object") return null;
+    const obj = entry;
+    const id = typeof obj.id === "string" ? obj.id.trim() : "";
+    if (!id) return null;
+    const name = typeof obj.name === "string" ? obj.name.trim() : "";
+    const createdAtMs = typeof obj.created === "number" && Number.isFinite(obj.created) && obj.created > 0
+      ? Math.round(obj.created * 1000)
+      : null;
+    return {
+      id,
+      name,
+      createdAtMs,
+      collectionPriority: getCollectionPriorityIndex(id)
+    };
+  }
+
+  function isDigestCompatibleModel(entry) {
+    const text = `${entry?.id || ""} ${entry?.name || ""}`.toLowerCase();
+    if (text.includes("embed")) return false;
+    if (text.includes("vl")) return false;
+    if (text.includes("vision")) return false;
+    return true;
+  }
+
+  function isFreeModel(entry) {
+    const id = entry?.id || "";
+    // 明示的な free リストに入るか、モデルID末尾が -free のもの
+    if (COLLECTION_PRIORITY_INDEX.has(id)) return true;
+    if (id.endsWith("-free")) return true;
+    // big-pickle はリストで明示
+    if (id === "big-pickle") return true;
+    return false;
+  }
+
+  function refreshDigestFreeModels({
+    catalog,
+    preferredModel,
+    maxAgeDays = DEFAULT_MAX_AGE_DAYS
+  } = {}) {
+    const now = Date.now();
+    const maxAgeMs = maxAgeDays > 0 ? maxAgeDays * 24 * 60 * 60 * 1000 : 0;
+    const entries = (Array.isArray(catalog) ? catalog : [])
+      .map(toModelEntry)
+      .filter((entry) => Boolean(entry));
+
+    const freeModels = entries.filter((entry) => isFreeModel(entry));
+    const digestCompatible = freeModels.filter((entry) => isDigestCompatibleModel(entry));
+    const ageFiltered = digestCompatible.filter((entry) => {
+      if (maxAgeMs <= 0) return true;
+      if (entry.createdAtMs === null) {
+        return Number.isFinite(entry.collectionPriority);
+      }
+      const age = now - entry.createdAtMs;
+      return age >= 0 && age <= maxAgeMs;
+    });
+
+    const sorted = ageFiltered.slice().sort((a, b) => {
+      const aPriority = a.collectionPriority ?? Number.POSITIVE_INFINITY;
+      const bPriority = b.collectionPriority ?? Number.POSITIVE_INFINITY;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      const aCreated = a.createdAtMs ?? -1;
+      const bCreated = b.createdAtMs ?? -1;
+      if (aCreated !== bCreated) return bCreated - aCreated;
+      return a.id.localeCompare(b.id);
+    });
+
+    const refreshedCandidates = sorted.map((entry) => entry.id);
+    return {
+      candidates: buildCandidateList({ preferredModel, candidates: refreshedCandidates }),
+      stats: {
+        catalogCount: entries.length,
+        freeCount: freeModels.length,
+        digestCompatibleCount: digestCompatible.length,
+        ageFilteredCount: ageFiltered.length,
+        finalCount: sorted.length,
+        maxAgeDays
+      }
+    };
+  }
+
+  async function tryCandidates({ preferredModel, candidates, attempt, onAttemptStart, onAttemptFailure }) {
+    const orderedCandidates = buildCandidateList({ preferredModel, candidates });
+    const attempts = [];
+    let lastError = null;
+
+    for (const modelId of orderedCandidates) {
+      try {
+        if (typeof onAttemptStart === "function") {
+          await onAttemptStart({ modelId, attempts: attempts.slice() });
+        }
+        const value = await attempt(modelId);
+        if (!String(value || "").trim()) {
+          throw new Error("OpenCode Zen response was empty");
+        }
+        return {
+          ok: true,
+          modelId,
+          value: String(value).trim(),
+          attempts
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error || "Unknown error");
+        const failure = {
+          modelId,
+          kind: classifyOpenCodeZenError(error),
+          error: message
+        };
+        attempts.push(failure);
+        if (typeof onAttemptFailure === "function") {
+          await onAttemptFailure({ ...failure, attempts: attempts.slice() });
+        }
+        lastError = error;
+      }
+    }
+
+    return {
+      ok: false,
+      error: lastError instanceof Error ? lastError.message : String(lastError || "No working OpenCode Zen free models"),
+      attempts
+    };
+  }
+
+  self.MirrorChatOpenCodeZenFreeModels = {
+    getCollectionPriorityModels,
+    getDefaultDigestFreeModels,
+    buildCandidateList,
+    buildKnownFreeModelList,
+    buildSelectOptions,
+    summarizeModelAvailability,
+    classifyOpenCodeZenError,
+    refreshDigestFreeModels,
+    tryCandidates
+  };
+})();

--- a/ai-prompt-broadcaster/options.html
+++ b/ai-prompt-broadcaster/options.html
@@ -26,38 +26,58 @@
       </section>
 
       <section>
-        <h2>OpenRouter（Digest生成用）</h2>
-        <label class="checkbox-row">
-          <input id="openrouter-enable-digest" type="checkbox" />
-          <span>回答保存後に digest を非同期生成する</span>
-        </label>
+        <h2>Digest 生成（要約）</h2>
         <label>
-          OpenRouter API キー
-          <input id="openrouter-api-key" type="password" placeholder="sk-or-..." />
+          プロバイダー
+          <select id="digest-provider">
+            <option value="">無効</option>
+            <option value="openrouter">OpenRouter</option>
+            <option value="opencodezen">OpenCode Zen</option>
+          </select>
         </label>
-        <details class="advanced-settings">
-          <summary>高度な設定</summary>
-          <label>
-            使用モデルを固定する（任意）
-            <select id="openrouter-preferred-model"></select>
-          </label>
-          <div class="actions">
-            <button id="openrouter-refresh-models-button" type="button">free候補を手動更新</button>
-            <span id="openrouter-refresh-status" aria-live="polite"></span>
+        <details id="digest-provider-settings" class="advanced-settings" open>
+          <summary>provider 設定</summary>
+
+          <div id="openrouter-settings">
+            <h3>OpenRouter</h3>
+            <label>
+              OpenRouter API キー
+              <input id="openrouter-api-key" type="password" placeholder="sk-or-..." />
+            </label>
           </div>
-          <p id="openrouter-refresh-meta"></p>
-          <p>digest 実行前には free 候補を自動更新します。ここでは候補一覧を先に確認・更新できます。</p>
-          <label>
-            APIテスト対象モデル（任意）
-            <select id="openrouter-test-model"></select>
-          </label>
-          <div class="actions diagnostic-actions">
-            <button id="openrouter-test-button" type="button">digest APIをテスト</button>
-            <button id="openrouter-test-copy-button" type="button">ログをコピー</button>
-            <span id="openrouter-test-status" aria-live="polite"></span>
+
+          <div id="opencodezen-settings">
+            <h3>OpenCode Zen</h3>
+            <label>
+              OpenCode Zen API キー
+              <input id="opencodezen-api-key" type="password" placeholder="sk-..." />
+            </label>
           </div>
-          <p>このテストは digest 本番と同じ候補解決・chat/completions 実行経路を使います。モデルIDを入れた場合はその1件だけ、空欄の場合は候補順に最大4モデルを試して詳細ログを表示します。</p>
-          <pre id="openrouter-test-log" class="log-output" aria-live="polite"></pre>
+
+          <details class="advanced-settings">
+            <summary>高度な設定</summary>
+            <label>
+              使用モデルを固定する（任意）
+              <select id="openrouter-preferred-model"></select>
+            </label>
+            <div class="actions">
+              <button id="openrouter-refresh-models-button" type="button">free候補を手動更新</button>
+              <span id="openrouter-refresh-status" aria-live="polite"></span>
+            </div>
+            <p id="openrouter-refresh-meta"></p>
+            <p>digest 実行前には free 候補を自動更新します。ここでは候補一覧を先に確認・更新できます。</p>
+            <label>
+              APIテスト対象モデル（任意）
+              <select id="openrouter-test-model"></select>
+            </label>
+            <div class="actions diagnostic-actions">
+              <button id="openrouter-test-button" type="button">digest APIをテスト</button>
+              <button id="openrouter-test-copy-button" type="button">ログをコピー</button>
+              <span id="openrouter-test-status" aria-live="polite"></span>
+            </div>
+            <p>このテストは digest 本番と同じ候補解決・chat/completions 実行経路を使います。モデルIDを入れた場合はその1件だけ、空欄の場合は候補順に最大4モデルを試して詳細ログを表示します。</p>
+            <pre id="openrouter-test-log" class="log-output" aria-live="polite"></pre>
+          </details>
         </details>
       </section>
 
@@ -241,6 +261,8 @@
     <script src="storage.js"></script>
     <script src="openRouterFreeModels.js"></script>
     <script src="openRouterClient.js"></script>
+    <script src="openCodeZenFreeModels.js"></script>
+    <script src="openCodeZenClient.js"></script>
     <script src="digestService.js"></script>
     <script src="options.js"></script>
   </body>

--- a/ai-prompt-broadcaster/options.js
+++ b/ai-prompt-broadcaster/options.js
@@ -26,7 +26,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const openCodeZenFreeModels = self.MirrorChatOpenCodeZenFreeModels;
   const digestService = self.MirrorChatDigestService;
   const constants = window.MirrorChatConstants || {};
-  // DOM 参照（provider非依存 един интерфейс）
   const AI_DEFAULT_ORDER = constants.AI_DEFAULT_ORDER || ["gemini", "chatgpt", "claude", "grok"];
   const AI_CONFIG_DEFAULTS = constants.AI_CONFIG_DEFAULTS || {};
   const aiOrderUtils = window.MirrorChatAIOrderUtils;
@@ -132,6 +131,32 @@ document.addEventListener("DOMContentLoaded", async () => {
       .join("\n");
   }
 
+  function buildDigestSettingsFromInputs(settings) {
+    const providerValue = digestProviderInput.value.trim().toLowerCase();
+    const nextSettings = {
+      ...settings,
+      digestProvider: providerValue || settings?.digestProvider || "",
+      openrouter: {
+        ...(settings?.openrouter || {}),
+        apiKey: openRouterApiKeyInput.value.trim() || settings?.openrouter?.apiKey || "",
+        preferredModel: providerValue === "openrouter"
+          ? (openRouterPreferredModelInput.value.trim() || "")
+          : (settings?.openrouter?.preferredModel || "")
+      },
+      opencodezen: {
+        ...(settings?.opencodezen || {}),
+        apiKey: openCodeZenApiKeyInput.value.trim() || settings?.opencodezen?.apiKey || "",
+        preferredModel: providerValue === "opencodezen"
+          ? (openRouterPreferredModelInput.value.trim() || "")
+          : (settings?.opencodezen?.preferredModel || "")
+      }
+    };
+    if (!nextSettings.digestProvider && settings?.openrouter?.enableDigest) {
+      nextSettings.digestProvider = "openrouter";
+    }
+    return nextSettings;
+  }
+
   function populateTestModelSuggestions(settings) {
     const provider = digestService.resolveProvider(settings);
     const freeModelSelector = provider.name === "opencodezen"
@@ -161,7 +186,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   async function runOpenRouterDiagnostic() {
-    const settings = await storage.getSettings();
+    const storedSettings = await storage.getSettings();
+    const settings = buildDigestSettingsFromInputs(storedSettings);
     const provider = digestService.resolveProvider(settings);
     if (!provider.apiKey) {
       setOpenRouterTestStatus(`${provider.name} の API キーを入力してください。`, "error");
@@ -195,6 +221,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const diagnosticRun = await digestService.runDigestPrompt({
         prompt,
         settings,
+        requestedModel: openRouterTestModelInput.value.trim(),
         fetchImpl: fetch,
         attemptLimit: OPENROUTER_TEST_ATTEMPT_LIMIT
       });
@@ -465,7 +492,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   openRouterRefreshButton.addEventListener("click", async () => {
-    const settings = await storage.getSettings();
+    const storedSettings = await storage.getSettings();
+    const settings = buildDigestSettingsFromInputs(storedSettings);
     const provider = digestService.resolveProvider(settings);
     if (!provider.apiKey) {
       openRouterRefreshStatus.textContent = `${provider.name} の API キーを入力してください。`;

--- a/ai-prompt-broadcaster/options.js
+++ b/ai-prompt-broadcaster/options.js
@@ -157,6 +157,31 @@ document.addEventListener("DOMContentLoaded", async () => {
     return nextSettings;
   }
 
+  function getProviderDisplayName(providerName) {
+    return providerName === "opencodezen" ? "OpenCode Zen" : "OpenRouter";
+  }
+
+  function refreshDigestProviderUi(settings, options = {}) {
+    const nextSettings = buildDigestSettingsFromInputs(settings);
+    const provider = digestService.resolveProvider(nextSettings);
+    const providerSettings = provider.name === "opencodezen"
+      ? nextSettings.opencodezen
+      : nextSettings.openrouter;
+
+    populatePreferredModelOptions(nextSettings);
+    populateTestModelSuggestions(nextSettings);
+    openRouterRefreshMeta.textContent = formatRefreshMeta(
+      providerSettings,
+      getProviderDisplayName(provider.name)
+    );
+
+    if (options.resetStatus !== false) {
+      openRouterRefreshStatus.textContent = "";
+      setOpenRouterTestStatus("", "info");
+      openRouterTestLog.textContent = "";
+    }
+  }
+
   function populateTestModelSuggestions(settings) {
     const provider = digestService.resolveProvider(settings);
     const freeModelSelector = provider.name === "opencodezen"
@@ -382,16 +407,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     digestProviderInput.value = settings.digestProvider || "";
     openRouterApiKeyInput.value = settings.openrouter?.apiKey || "";
     openCodeZenApiKeyInput.value = settings.opencodezen?.apiKey || "";
-    populatePreferredModelOptions(settings);
-    populateTestModelSuggestions(settings);
-    const provider = digestService.resolveProvider(settings);
-    openRouterRefreshMeta.textContent = formatRefreshMeta(
-      provider.name === "opencodezen" ? settings.opencodezen : settings.openrouter,
-      provider.name === "opencodezen" ? "OpenCode Zen" : "OpenRouter"
-    );
-    openRouterRefreshStatus.textContent = "";
-    setOpenRouterTestStatus("", "info");
-    openRouterTestLog.textContent = "";
+    refreshDigestProviderUi(settings);
     openRouterTestModelInput.value = "";
     setOpenRouterTestButtonsDisabled(false);
 
@@ -549,6 +565,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         "error"
       );
     });
+  });
+
+  digestProviderInput.addEventListener("change", async () => {
+    const settings = await storage.getSettings();
+    refreshDigestProviderUi(settings);
   });
 
   aiOrderList?.addEventListener("click", (event) => {

--- a/ai-prompt-broadcaster/options.js
+++ b/ai-prompt-broadcaster/options.js
@@ -4,8 +4,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const baseUrlInput = document.getElementById("obsidian-base-url");
   const tokenInput = document.getElementById("obsidian-token");
   const rootPathInput = document.getElementById("obsidian-root-path");
-  const openRouterEnableDigestInput = document.getElementById("openrouter-enable-digest");
+  const digestProviderInput = document.getElementById("digest-provider");
   const openRouterApiKeyInput = document.getElementById("openrouter-api-key");
+  const openCodeZenApiKeyInput = document.getElementById("opencodezen-api-key");
   const openRouterPreferredModelInput = document.getElementById("openrouter-preferred-model");
   const openRouterRefreshButton = document.getElementById("openrouter-refresh-models-button");
   const openRouterRefreshStatus = document.getElementById("openrouter-refresh-status");
@@ -21,10 +22,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   const aiConfigList = document.getElementById("ai-config-list");
 
   const storage = window.MirrorChatStorage;
-  const openRouterClient = window.MirrorChatOpenRouterClient;
-  const openRouterFreeModels = window.MirrorChatOpenRouterFreeModels;
-  const digestService = window.MirrorChatDigestService;
+  const openRouterFreeModels = self.MirrorChatOpenRouterFreeModels;
+  const openCodeZenFreeModels = self.MirrorChatOpenCodeZenFreeModels;
+  const digestService = self.MirrorChatDigestService;
   const constants = window.MirrorChatConstants || {};
+  // DOM 参照（provider非依存 един интерфейс）
   const AI_DEFAULT_ORDER = constants.AI_DEFAULT_ORDER || ["gemini", "chatgpt", "claude", "grok"];
   const AI_CONFIG_DEFAULTS = constants.AI_CONFIG_DEFAULTS || {};
   const aiOrderUtils = window.MirrorChatAIOrderUtils;
@@ -131,9 +133,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function populateTestModelSuggestions(settings) {
-    const candidates = openRouterFreeModels.buildKnownFreeModelList({
-      preferredModel: settings?.openrouter?.preferredModel,
-      candidates: settings?.openrouter?.freeModelCandidatesOverride
+    const provider = digestService.resolveProvider(settings);
+    const freeModelSelector = provider.name === "opencodezen"
+      ? openCodeZenFreeModels
+      : openRouterFreeModels;
+    const candidates = freeModelSelector.buildKnownFreeModelList({
+      preferredModel: provider.preferredModel,
+      candidates: provider.freeModelCandidatesOverride
     });
     const currentValue = openRouterTestModelInput.value;
     openRouterTestModelInput.innerHTML = "";
@@ -156,15 +162,13 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   async function runOpenRouterDiagnostic() {
     const settings = await storage.getSettings();
-    const apiKey = openRouterApiKeyInput.value.trim() || settings.openrouter?.apiKey || "";
-    if (!apiKey) {
-      setOpenRouterTestStatus("OpenRouter API キーを入力してください。", "error");
+    const provider = digestService.resolveProvider(settings);
+    if (!provider.apiKey) {
+      setOpenRouterTestStatus(`${provider.name} の API キーを入力してください。`, "error");
       openRouterTestLog.textContent = "API キーが未設定のため診断を開始できません。";
       return;
     }
 
-    const preferredModel = openRouterPreferredModelInput.value.trim();
-    const requestedTestModel = openRouterTestModelInput.value.trim();
     const prompt = digestService?.buildDigestDiagnosticPrompt
       ? digestService.buildDigestDiagnosticPrompt()
       : {
@@ -179,20 +183,18 @@ document.addEventListener("DOMContentLoaded", async () => {
     };
 
     setOpenRouterTestButtonsDisabled(true);
-    setOpenRouterTestStatus("digest API をテスト中...", "info");
+    setOpenRouterTestStatus(`${provider.name} digest API をテスト中...`, "info");
     openRouterTestLog.textContent = "";
 
     try {
       appendLog(`[開始] ${new Date().toLocaleString("ja-JP")}`);
       appendLog(
-        `[設定] preferredModel=${preferredModel || "(自動選択)"} / testModel=${requestedTestModel || "(自動候補順)"}`
+        `[設定] provider=${provider.name} / preferredModel=${provider.preferredModel || "(自動選択)"} / ` +
+        `testModel=${openRouterTestModelInput.value.trim() || "(自動候補順)"}`
       );
       const diagnosticRun = await digestService.runDigestPrompt({
         prompt,
         settings,
-        apiKey,
-        preferredModel,
-        requestedModel: requestedTestModel,
         fetchImpl: fetch,
         attemptLimit: OPENROUTER_TEST_ATTEMPT_LIMIT
       });
@@ -201,24 +203,14 @@ document.addEventListener("DOMContentLoaded", async () => {
         `[リクエスト] timeout=${runtime.timeoutMs || 0}ms / systemPrompt=${prompt.systemPrompt.length} chars / userPrompt=${prompt.userPrompt.length} chars`
       );
 
-      if (diagnosticRun.candidateResolution?.source === "requested") {
-        appendLog("");
-        appendLog(`[候補指定] 手動指定モデルをテストします: ${requestedTestModel}`);
+      if (diagnosticRun.candidateResolution?.source === "catalog") {
+        appendLog(
+          `[候補取得] 成功: catalog=${diagnosticRun.refreshedStats?.catalogCount ?? 0}件 / 診断候補=${diagnosticRun.candidateResolution?.attemptedCandidates?.length ?? 0}件`
+        );
       } else {
-        appendLog("");
-        appendLog("[候補取得] /models を確認しています...");
-        if (diagnosticRun.candidateResolution?.source === "catalog") {
-          appendLog(
-            `[候補取得] 成功: catalog=${diagnosticRun.refreshedStats?.catalogCount ?? 0}件 / 診断候補=${diagnosticRun.candidateResolution?.attemptedCandidates?.length ?? 0}件`
-          );
-        } else {
-          appendLog(
-            `[候補取得] 失敗: ${diagnosticRun.candidateResolution?.catalogError?.error || diagnosticRun.error || "不明なエラー"}`
-          );
-          appendLog(
-            `[候補取得] 保存済み/既定候補で続行: ${diagnosticRun.candidateResolution?.attemptedCandidates?.length ?? 0}件`
-          );
-        }
+        appendLog(
+          `[候補取得] 保存済み/既定候補で続行: ${diagnosticRun.candidateResolution?.attemptedCandidates?.length ?? 0}件`
+        );
       }
 
       const diagnosticCandidates = Array.isArray(diagnosticRun.candidateResolution?.attemptedCandidates)
@@ -305,9 +297,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function populatePreferredModelOptions(settings) {
-    const options = openRouterFreeModels.buildSelectOptions({
-      preferredModel: settings?.openrouter?.preferredModel,
-      candidates: settings?.openrouter?.freeModelCandidatesOverride
+    const provider = digestService.resolveProvider(settings);
+    const freeModelSelector = provider.name === "opencodezen"
+      ? openCodeZenFreeModels
+      : openRouterFreeModels;
+    const options = freeModelSelector.buildSelectOptions({
+      preferredModel: provider.preferredModel,
+      candidates: provider.freeModelCandidatesOverride
     });
     openRouterPreferredModelInput.innerHTML = "";
     options.forEach(({ value, label }) => {
@@ -316,18 +312,23 @@ document.addEventListener("DOMContentLoaded", async () => {
       option.textContent = label;
       openRouterPreferredModelInput.appendChild(option);
     });
-    openRouterPreferredModelInput.value = settings?.openrouter?.preferredModel || "";
+    openRouterPreferredModelInput.value = provider.preferredModel || "";
   }
 
-  function formatRefreshMeta(openRouterSettings) {
-    const summary = openRouterFreeModels.summarizeModelAvailability({
-      preferredModel: openRouterSettings?.preferredModel,
-      candidates: openRouterSettings?.freeModelCandidatesOverride,
-      stats: openRouterSettings?.lastRefreshStats,
-      lastRefreshAt: openRouterSettings?.lastRefreshAt
-    });
-    if (!summary.hasRefreshInfo) {
-      return `更新済み候補はまだありません。プルダウン表示: ${summary.selectableCount}件（既定候補）`;
+  function formatRefreshMeta(providerSettings, providerName) {
+    const candidates = providerSettings?.freeModelCandidatesOverride || [];
+    const stats = providerSettings?.lastRefreshStats || {};
+    const lastRefreshAt = providerSettings?.lastRefreshAt || "";
+    const summary = {
+      digestCandidateCount: candidates.length,
+      selectableCount: candidates.length,
+      freeCount: stats.freeCount ?? null,
+      catalogCount: stats.catalogCount ?? null,
+      digestCompatibleCount: stats.digestCompatibleCount ?? null,
+      lastRefreshAt
+    };
+    if (candidates.length === 0 && !summary.lastRefreshAt) {
+      return `更新済み候補はまだありません（${providerName} の既定候補）`;
     }
     const parts = [];
     if (summary.freeCount !== null) {
@@ -351,11 +352,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     baseUrlInput.value = settings.obsidian.baseUrl || "";
     tokenInput.value = settings.obsidian.token || "";
     rootPathInput.value = settings.obsidian.rootPath || "";
-    openRouterEnableDigestInput.checked = !!settings.openrouter?.enableDigest;
+    digestProviderInput.value = settings.digestProvider || "";
     openRouterApiKeyInput.value = settings.openrouter?.apiKey || "";
+    openCodeZenApiKeyInput.value = settings.opencodezen?.apiKey || "";
     populatePreferredModelOptions(settings);
     populateTestModelSuggestions(settings);
-    openRouterRefreshMeta.textContent = formatRefreshMeta(settings.openrouter);
+    const provider = digestService.resolveProvider(settings);
+    openRouterRefreshMeta.textContent = formatRefreshMeta(
+      provider.name === "opencodezen" ? settings.opencodezen : settings.openrouter,
+      provider.name === "opencodezen" ? "OpenCode Zen" : "OpenRouter"
+    );
     openRouterRefreshStatus.textContent = "";
     setOpenRouterTestStatus("", "info");
     openRouterTestLog.textContent = "";
@@ -384,6 +390,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   async function save() {
+    const providerValue = digestProviderInput.value.trim();
     const partial = {
       aiOrder: [...currentAiOrder],
       obsidian: {
@@ -391,10 +398,18 @@ document.addEventListener("DOMContentLoaded", async () => {
         token: tokenInput.value.trim(),
         rootPath: rootPathInput.value.trim()
       },
+      digestProvider: providerValue || null,
       openrouter: {
-        enableDigest: !!openRouterEnableDigestInput.checked,
         apiKey: openRouterApiKeyInput.value.trim(),
-        preferredModel: openRouterPreferredModelInput.value.trim() || null
+        preferredModel: providerValue === "openrouter"
+          ? (openRouterPreferredModelInput.value.trim() || null)
+          : null
+      },
+      opencodezen: {
+        apiKey: openCodeZenApiKeyInput.value.trim(),
+        preferredModel: providerValue === "opencodezen"
+          ? (openRouterPreferredModelInput.value.trim() || null)
+          : null
       },
       aiConfigs: {}
     };
@@ -451,34 +466,39 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   openRouterRefreshButton.addEventListener("click", async () => {
     const settings = await storage.getSettings();
-    const apiKey = openRouterApiKeyInput.value.trim() || settings.openrouter?.apiKey || "";
+    const provider = digestService.resolveProvider(settings);
+    if (!provider.apiKey) {
+      openRouterRefreshStatus.textContent = `${provider.name} の API キーを入力してください。`;
+      return;
+    }
     openRouterRefreshButton.disabled = true;
-    openRouterRefreshStatus.textContent = "OpenRouter の free 候補を更新中...";
+    openRouterRefreshStatus.textContent = `${provider.name} の free 候補を更新中...`;
     try {
-      const catalog = await openRouterClient.fetchModelsCatalog({ apiKey, fetchImpl: fetch });
-      const refreshed = openRouterFreeModels.refreshDigestFreeModels({
+      const catalog = await provider.client.fetchModelsCatalog({ apiKey: provider.apiKey, fetchImpl: fetch });
+      const refreshed = provider.freeModelSelector.refreshDigestFreeModels({
         catalog,
         preferredModel: openRouterPreferredModelInput.value.trim()
       });
+      const providerKey = provider.name === "opencodezen" ? "opencodezen" : "openrouter";
       const nextSettings = await storage.saveSettings({
-        openrouter: {
+        [providerKey]: {
           freeModelCandidatesOverride: refreshed.candidates,
           lastRefreshStats: refreshed.stats,
           lastRefreshAt: new Date().toISOString()
         }
       });
-      const summary = openRouterFreeModels.summarizeModelAvailability({
-        preferredModel: nextSettings?.openrouter?.preferredModel,
-        candidates: nextSettings?.openrouter?.freeModelCandidatesOverride,
-        stats: nextSettings?.openrouter?.lastRefreshStats,
-        lastRefreshAt: nextSettings?.openrouter?.lastRefreshAt
-      });
+      const providerSettings = provider.name === "opencodezen"
+        ? nextSettings.opencodezen
+        : nextSettings.openrouter;
       openRouterRefreshStatus.textContent =
-        `free取得 ${summary.freeCount ?? 0}件 / digest候補 ${summary.digestCandidateCount}件 / ` +
-        `プルダウン表示 ${summary.selectableCount}件 を更新しました。`;
+        `free取得 ${refreshed.stats.freeCount ?? 0}件 / digest候補 ${refreshed.candidates.length}件 / ` +
+        `プルダウン表示 ${refreshed.candidates.length}件 を更新しました。`;
       populatePreferredModelOptions(nextSettings);
       populateTestModelSuggestions(nextSettings);
-      openRouterRefreshMeta.textContent = formatRefreshMeta(nextSettings.openrouter);
+      openRouterRefreshMeta.textContent = formatRefreshMeta(
+        providerSettings,
+        provider.name === "opencodezen" ? "OpenCode Zen" : "OpenRouter"
+      );
     } catch (error) {
       openRouterRefreshStatus.textContent = `候補更新に失敗しました: ${error instanceof Error ? error.message : String(error)}`;
     } finally {

--- a/ai-prompt-broadcaster/popup.html
+++ b/ai-prompt-broadcaster/popup.html
@@ -74,6 +74,7 @@
     <script src="aiOrderUtils.js"></script>
     <script src="storage.js"></script>
     <script src="openRouterFreeModels.js"></script>
+    <script src="openCodeZenFreeModels.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/ai-prompt-broadcaster/popup.js
+++ b/ai-prompt-broadcaster/popup.js
@@ -46,6 +46,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const currentTaskKey = constants.STORAGE_KEYS?.CURRENT_TASK ?? "mirrorchatCurrentTask";
   const failedItemsKey = constants.STORAGE_KEYS?.FAILED_ITEMS ?? "mirrorchatFailedItems";
   const lastNoteSnapshotKey = constants.STORAGE_KEYS?.LAST_NOTE_SNAPSHOT ?? "mirrorchatLastNoteSnapshot";
+  const settingsKey = constants.STORAGE_KEYS?.SETTINGS ?? "mirrorchatSettings";
 
   const MSG_GET_TAB_STATUS = MESSAGE_TYPES.GET_TAB_STATUS || "MIRRORCHAT_GET_TAB_STATUS";
   const MSG_OPEN_TABS = MESSAGE_TYPES.OPEN_TABS || "MIRRORCHAT_OPEN_TABS";
@@ -61,6 +62,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const MSG_DONE = MESSAGE_TYPES.DONE || "MIRRORCHAT_DONE";
   const storage = window.MirrorChatStorage;
   const openRouterFreeModels = window.MirrorChatOpenRouterFreeModels;
+  const openCodeZenFreeModels = window.MirrorChatOpenCodeZenFreeModels;
 
   const indicators = {};
   const aiCheckboxes = {};
@@ -113,17 +115,38 @@ document.addEventListener("DOMContentLoaded", async () => {
     busyAction: ""
   };
 
+  function resolveDigestProviderConfig(settings) {
+    const providerName = String(
+      settings?.digestProvider || (settings?.openrouter?.enableDigest ? "openrouter" : "")
+    ).trim().toLowerCase();
+    if (providerName === "opencodezen") {
+      return {
+        name: "opencodezen",
+        preferredModel: settings?.opencodezen?.preferredModel,
+        freeModelCandidatesOverride: settings?.opencodezen?.freeModelCandidatesOverride,
+        selector: openCodeZenFreeModels
+      };
+    }
+    return {
+      name: "openrouter",
+      preferredModel: settings?.openrouter?.preferredModel,
+      freeModelCandidatesOverride: settings?.openrouter?.freeModelCandidatesOverride,
+      selector: openRouterFreeModels
+    };
+  }
+
   function buildDigestModelOptions(settings) {
-    if (openRouterFreeModels?.buildSelectOptions) {
-      return openRouterFreeModels.buildSelectOptions({
-        preferredModel: settings?.openrouter?.preferredModel,
-        candidates: settings?.openrouter?.freeModelCandidatesOverride
+    const provider = resolveDigestProviderConfig(settings);
+    if (provider.selector?.buildSelectOptions) {
+      return provider.selector.buildSelectOptions({
+        preferredModel: provider.preferredModel,
+        candidates: provider.freeModelCandidatesOverride
       }).map((option, index) => (index === 0 ? { ...option, label: "自動選択" } : option));
     }
 
-    const preferredModel = String(settings?.openrouter?.preferredModel || "").trim();
-    const candidates = Array.isArray(settings?.openrouter?.freeModelCandidatesOverride)
-      ? settings.openrouter.freeModelCandidatesOverride
+    const preferredModel = String(provider.preferredModel || "").trim();
+    const candidates = Array.isArray(provider.freeModelCandidatesOverride)
+      ? provider.freeModelCandidatesOverride
       : [];
     const unique = new Set();
     const ordered = [];
@@ -502,6 +525,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       void syncLastSavedNoteState();
       refreshTabStatus();
     }
+  });
+
+  chrome.storage.onChanged?.addListener((changes, areaName) => {
+    if (areaName !== "sync") return;
+    if (!Object.prototype.hasOwnProperty.call(changes || {}, settingsKey)) return;
+    void syncLastSavedNoteState();
   });
 
   await syncRetryState();

--- a/ai-prompt-broadcaster/storage.js
+++ b/ai-prompt-broadcaster/storage.js
@@ -53,8 +53,17 @@
       token: "",
       rootPath: "200-AI Research"
     },
+    digestProvider: "",
     openrouter: {
       enableDigest: false,
+      apiKey: "",
+      preferredModel: "",
+      freeModelCandidatesOverride: [],
+      recentDigestFailures: {},
+      lastRefreshStats: {},
+      lastRefreshAt: ""
+    },
+    opencodezen: {
       apiKey: "",
       preferredModel: "",
       freeModelCandidatesOverride: [],

--- a/ai-prompt-broadcaster/storage.js
+++ b/ai-prompt-broadcaster/storage.js
@@ -104,8 +104,11 @@
   }
 
   function sanitizeSettings(settings) {
+    const digestProvider = String(settings?.digestProvider || "").trim().toLowerCase();
+    const migratedDigestProvider = digestProvider || (settings?.openrouter?.enableDigest ? "openrouter" : "");
     return {
       ...settings,
+      digestProvider: migratedDigestProvider,
       aiOrder: normalizeAiOrder(settings?.aiOrder)
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,912 @@
+{
+  "name": "mirror-chat",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mirror-chat",
+      "devDependencies": {
+        "@eslint/js": "10",
+        "eslint": "^10.1.0",
+        "globals": "^17.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/tests/obsidian-storage.test.mjs
+++ b/tests/obsidian-storage.test.mjs
@@ -71,3 +71,58 @@ test("replaceDigestSection keeps ChatGPT answer block intact", async () => {
   assert.ok(!replaced.content.includes("MIRRORCHAT_DIGEST_START"));
   assert.ok(!replaced.content.includes("MIRRORCHAT_DIGEST_END"));
 });
+
+test("saveToObsidian writes pending digest placeholder for provider-based digest", async () => {
+  const storage = new Map();
+  let capturedContent = "";
+  const code = await readFile("./ai-prompt-broadcaster/obsidianStorage.js", "utf8");
+  const context = vm.createContext({
+    self: {
+      MirrorChatConstants: {
+        STORAGE_KEYS: {
+          FOLDER_SEQ: "folder",
+          LAST_SAVED_FOLDER: "last",
+          QUESTION_FILE_SEQ: "question"
+        }
+      },
+      ObsidianClient: {
+        async createNote(_baseUrl, _token, _notePath, content) {
+          capturedContent = content;
+          return { ok: true };
+        }
+      }
+    },
+    chrome: {
+      storage: {
+        local: {
+          get(key, callback) {
+            callback({ [key]: storage.get(key) || {} });
+          },
+          set(value, callback) {
+            Object.entries(value).forEach(([key, entry]) => storage.set(key, entry));
+            callback();
+          }
+        }
+      }
+    },
+    console
+  });
+  vm.runInContext(code, context, { filename: "./ai-prompt-broadcaster/obsidianStorage.js" });
+
+  const obsidianStorage = context.self.MirrorChatObsidianStorage;
+  const result = await obsidianStorage.saveToObsidian(
+    "質問本文",
+    [{ name: "ChatGPT", markdown: "回答本文" }],
+    {
+      digestProvider: "opencodezen",
+      obsidian: {
+        baseUrl: "http://127.0.0.1:27123/",
+        token: "",
+        rootPath: "200-AI Research"
+      }
+    }
+  );
+
+  assert.equal(result.ok, true);
+  assert.match(capturedContent, /## まとめ\n\n生成中.../);
+});

--- a/tests/storage-settings.test.mjs
+++ b/tests/storage-settings.test.mjs
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+async function loadStorageContext(storedSettings) {
+  const code = await readFile("./ai-prompt-broadcaster/storage.js", "utf8");
+  const context = vm.createContext({
+    self: {
+      MirrorChatConstants: {
+        STORAGE_KEYS: {
+          SETTINGS: "mirrorchatSettings"
+        },
+        AI_KEYS: ["chatgpt", "claude", "gemini", "grok"],
+        AI_DEFAULT_ORDER: ["gemini", "chatgpt", "claude", "grok"],
+        AI_CONFIG_DEFAULTS: {}
+      },
+      MirrorChatAIOrderUtils: {
+        normalizeAiOrder(value) {
+          return Array.isArray(value) && value.length > 0
+            ? value
+            : ["gemini", "chatgpt", "claude", "grok"];
+        }
+      }
+    },
+    window: undefined,
+    chrome: {
+      storage: {
+        sync: {
+          get(_key, callback) {
+            callback({ mirrorchatSettings: storedSettings });
+          },
+          set(_value, callback) {
+            callback();
+          }
+        }
+      }
+    },
+    console
+  });
+  vm.runInContext(code, context, { filename: "./ai-prompt-broadcaster/storage.js" });
+  return context;
+}
+
+test("getSettings migrates legacy openrouter enableDigest to digestProvider", async () => {
+  const context = await loadStorageContext({
+    openrouter: {
+      enableDigest: true,
+      apiKey: "test"
+    }
+  });
+
+  const storage = context.self.MirrorChatStorage;
+  const settings = await storage.getSettings();
+
+  assert.equal(settings.digestProvider, "openrouter");
+  assert.equal(settings.openrouter.apiKey, "test");
+});


### PR DESCRIPTION
## Summary

Digest 生成（要約）機能で、OpenRouter に加えて **OpenCode Zen** をプロバイダーとして選択できるようになりました。

### 変更内容

| ファイル | 変更 |
|---|---|
| `openCodeZenClient.js` | 新規追加 — OpenCode Zen API のOpenAI互換RESTクライアント |
| `openCodeZenFreeModels.js` | 新規追加 — OpenCode Zen のfreeモデル選択ロジック |
| `digestService.js` | provider abstraction（`resolveProvider`）追加、両provider対応にリファクタ |
| `options.html` | プロバイダー切替select UI（無効 / OpenRouter / OpenCode Zen）を追加 |
| `options.js` | provider対応: refresh、diagnostic、設定保存をproviderに応じて切り替え |
| `storage.js` | `digestProvider` デフォルト設定、`opencodezen` 設定キーを追加 |
| `manifest.json` | `opencode.ai/*` host permission を追加 |

### 設定方法

1. Chrome拡張の設定画面を開く
2. 「Digest 生成」セクションでプロバイダーを **OpenCode Zen** に切り替え
3. OpenCode Zen APIキーを入力（オプション、freeモデルのみ利用可）
4. free候補を更新 → テスト実行で動作確認

### 利用可能なfreeモデル（OpenCode Zen）

- `big-pickle` ← 今回利用中のモデル
- `trinity-large-preview-free`
- `minimax-m2.5-free`
- `nemotron-3-super-free`

### テスト結果

- `npm run lint` → ✅ ESLint 0 errors
- `npm run test:unit` → ✅ 27/27 tests passed

### 後方互換性

既存の `openrouter` 設定はそのまま動作します。デフォルトは `digestProvider: null`（無効）のため、ユーザーは明示的に切り替える必要があります。